### PR TITLE
Potential fix for code scanning alert no. 70: Server-side request forgery

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1625,8 +1625,22 @@ export async function registerRoutes(app: Express): Promise<HttpServer> {
   app.post('/api/repo/contents', async (req, res) => {
     try {
       const { owner, repo, path: repoPath = '' } = req.body;
-      if (!owner || !repo) {
-        return res.status(400).json({ error: 'owner and repo are required' });
+
+      // Validation: Only allow valid GitHub owner/repo names and path
+      const githubNameRegex = /^[A-Za-z0-9_.-]{1,100}$/;
+      const repoPathRegex = /^([A-Za-z0-9_.\-\/]*)$/;
+
+      if (
+        !owner || !repo ||
+        !githubNameRegex.test(owner) ||
+        !githubNameRegex.test(repo) ||
+        typeof repoPath !== "string" ||
+        repoPath.length > 256 ||
+        repoPath.includes('..') ||
+        repoPath.startsWith('/') ||
+        !repoPathRegex.test(repoPath)
+      ) {
+        return res.status(400).json({ error: 'Invalid owner, repo, or path value.' });
       }
 
       const githubToken = process.env.GITHUB_TOKEN;


### PR DESCRIPTION
Potential fix for [https://github.com/mrdannyclark82/Milla-Rayne/security/code-scanning/70](https://github.com/mrdannyclark82/Milla-Rayne/security/code-scanning/70)

To remedy this SSRF risk, the best approach is to sanitize and strictly validate all user inputs used to construct the outbound URL:

- **Owner and repo validation:** Only allow valid GitHub usernames and repository names. These use a restricted character set (`A-Za-z0-9-_`) and lengths (<= 100 characters).
- **Repo path validation:** Restrict `repoPath` to not allow path traversal (no "`..`", not start with `/`, and obey GitHub’s allowed path formats).
- **Optional allow-listing:** If the use case only allows fetching from specific owners and repositories, restrict to those.
- **Escape/sanitize inputs:** Ensure that the constructed URL cannot be manipulated to hit unexpected endpoints.
- **Reject requests with invalid inputs:** Return an error if validation fails.

Edit the handler for `/api/repo/contents` to validate these three fields before using them in the request.

You will need:

- To add validation logic (using regex, length checks, and/or `zod` since it's already imported).
- To respond with a 400 error if the validation fails.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Reject requests to /api/repo/contents with invalid or potentially malicious owner, repo, or path values to address an SSRF vulnerability.