### PR TITLE
Fix missing storage mock in aiDispatcherPriority tests

### DIFF
--- a/server/__tests__/aiDispatcherPriority.test.ts
+++ b/server/__tests__/aiDispatcherPriority.test.ts
@@ -36,6 +36,7 @@ vi.mock('../storage', () => ({
     getUserPreferredAIModel: vi
       .fn()
       .mockRejectedValue(new Error('No preference')),
+    getUserById: vi.fn().mockResolvedValue(null),
   },
 }));
 


### PR DESCRIPTION
Fixed a test failure in `server/__tests__/aiDispatcherPriority.test.ts` where the `storage` mock was missing the `getUserById` method, causing a `TypeError` during test execution. The mock now includes `getUserById` returning `null`, consistent with the test scenarios. Confirmed all tests pass.

---
*PR created automatically by Jules for task [2770970712465782410](https://jules.google.com/task/2770970712465782410) started by @mrdannyclark82*

## Summary by Sourcery

Bug Fixes:
- Define a mocked storage.getUserById method returning null in aiDispatcherPriority tests to avoid TypeErrors during test execution.