### PR TITLE
Fix failing AI dispatcher priority tests

### DIFF
--- a/server/__tests__/aiDispatcherPriority.test.ts
+++ b/server/__tests__/aiDispatcherPriority.test.ts
@@ -31,11 +31,20 @@ vi.mock('../xaiTracker', () => ({
   trackResponseGeneration: vi.fn(),
   addReasoningStep: vi.fn(),
 }));
+vi.mock('../youtubeKnowledgeBase', () => ({
+  semanticSearchVideos: vi.fn().mockResolvedValue([]),
+}));
 vi.mock('../storage', () => ({
   storage: {
     getUserPreferredAIModel: vi
       .fn()
       .mockRejectedValue(new Error('No preference')),
+    getUserById: vi.fn().mockResolvedValue({
+      id: 'u1',
+      username: 'User',
+      email: 'user@example.com',
+      preferredAiModel: null,
+    }),
   },
 }));
 


### PR DESCRIPTION
The repository status check revealed failing tests in `server/__tests__/aiDispatcherPriority.test.ts`. The failures were caused by:
1.  Attempting real network calls to OpenAI for embeddings (via `semanticSearchVideos`), which failed due to an invalid test API key.
2.  Missing mock for `storage.getUserById`, causing a TypeError when `getUserAIModel` was called.

This change:
-   Mocks `../youtubeKnowledgeBase` to return empty results for `semanticSearchVideos`, bypassing the network call.
-   Updates the `../storage` mock to include `getUserById`, preventing the TypeError.
-   Ensures all tests pass locally.

This restores the health of the CI/CD pipeline.

---
*PR created automatically by Jules for task [17687699456295450704](https://jules.google.com/task/17687699456295450704) started by @mrdannyclark82*

## Summary by Sourcery

Stabilize AI dispatcher priority tests by mocking external dependencies and user retrieval.

Bug Fixes:
- Prevent AI dispatcher priority tests from attempting real network calls for semantic video search.
- Avoid TypeErrors in AI dispatcher priority tests by providing a mock implementation of user retrieval from storage.

Tests:
- Mock youtube knowledge base semantic search to return empty results in AI dispatcher priority tests.
- Extend storage mocks in AI dispatcher priority tests to include user lookup behavior.