### PR TITLE
Fix test failures and remove artifacts

### DIFF
--- a/memory/audio_messages/070bb50a-e923-4bae-aa40-313aae206614.webm
+++ b/memory/audio_messages/070bb50a-e923-4bae-aa40-313aae206614.webm
@@ -1,1 +1,0 @@
-dummy audio data

--- a/memory/audio_messages/0cd92b78-3958-445a-9edc-bf13f3751c69.webm
+++ b/memory/audio_messages/0cd92b78-3958-445a-9edc-bf13f3751c69.webm
@@ -1,1 +1,0 @@
-dummy audio data

--- a/memory/audio_messages/48e061af-ad10-436e-93cc-61f520192fd0.webm
+++ b/memory/audio_messages/48e061af-ad10-436e-93cc-61f520192fd0.webm
@@ -1,1 +1,0 @@
-dummy audio data

--- a/memory/audio_messages/83d51df8-bff2-4953-aed5-0b4c7f67ebab.webm
+++ b/memory/audio_messages/83d51df8-bff2-4953-aed5-0b4c7f67ebab.webm
@@ -1,1 +1,0 @@
-dummy audio data

--- a/memory/audio_messages/8f866964-14cc-4112-8427-2c039b627574.webm
+++ b/memory/audio_messages/8f866964-14cc-4112-8427-2c039b627574.webm
@@ -1,1 +1,0 @@
-dummy audio data

--- a/memory/audio_messages/a4b21c50-8404-4c84-a6e9-0fb7401a5e40.webm
+++ b/memory/audio_messages/a4b21c50-8404-4c84-a6e9-0fb7401a5e40.webm
@@ -1,1 +1,0 @@
-dummy audio data

--- a/memory/audio_messages/aca1e513-b582-40d1-97dd-c0c6606ff70b.webm
+++ b/memory/audio_messages/aca1e513-b582-40d1-97dd-c0c6606ff70b.webm
@@ -1,1 +1,0 @@
-dummy audio data

--- a/server/__tests__/aiDispatcherPriority.test.ts
+++ b/server/__tests__/aiDispatcherPriority.test.ts
@@ -31,11 +31,15 @@ vi.mock('../xaiTracker', () => ({
   trackResponseGeneration: vi.fn(),
   addReasoningStep: vi.fn(),
 }));
+vi.mock('../youtubeKnowledgeBase', () => ({
+  semanticSearchVideos: vi.fn().mockResolvedValue([]),
+}));
 vi.mock('../storage', () => ({
   storage: {
     getUserPreferredAIModel: vi
       .fn()
       .mockRejectedValue(new Error('No preference')),
+    getUserById: vi.fn().mockResolvedValue(null),
   },
 }));
 


### PR DESCRIPTION
This PR fixes failing tests in `server/__tests__/aiDispatcherPriority.test.ts` by adding missing mocks for `youtubeKnowledgeBase` and `storage`. It also cleans up some tracked audio artifacts in `memory/audio_messages` that should not be in the repository. The fix ensures that tests run cleanly without attempting external API calls or database operations that require authentication.

---
*PR created automatically by Jules for task [6045341693468084439](https://jules.google.com/task/6045341693468084439) started by @mrdannyclark82*

## Summary by Sourcery

Fix failing AI dispatcher priority tests by adding missing mocks and remove committed audio message artifacts from the repository.

Bug Fixes:
- Add mocks for YouTube knowledge base and user storage lookups to prevent AI dispatcher priority tests from calling external dependencies.

Chores:
- Delete tracked audio message .webm artifacts from the memory directory to keep the repository free of runtime-generated files.