### PR TITLE
Fix integer expression error in test-fixes.sh

### DIFF
--- a/test-fixes.sh
+++ b/test-fixes.sh
@@ -25,7 +25,7 @@ echo ""
 # Check TypeScript compilation
 echo "2. Checking TypeScript compilation..."
 npm run check > /tmp/ts-check.log 2>&1
-TS_ERRORS=$(grep -c "error TS" /tmp/ts-check.log || echo 0)
+TS_ERRORS=$(grep -c "error TS" /tmp/ts-check.log || true)
 if [ "$TS_ERRORS" -gt 0 ]; then
     echo "   ⚠️  Found $TS_ERRORS TypeScript errors (pre-existing)"
 else


### PR DESCRIPTION
Fixed a bug in `test-fixes.sh` where the script would output an "integer expression expected" error due to incorrect handling of `grep -c` output. The fix ensures that the script correctly counts TypeScript errors without syntax errors. Verified that the repository is in a healthy state with passing tests and builds.

---
*PR created automatically by Jules for task [17357450307256780121](https://jules.google.com/task/17357450307256780121) started by @mrdannyclark82*

## Summary by Sourcery

Bug Fixes:
- Prevent the TypeScript check step in test-fixes.sh from emitting an 'integer expression expected' error when grep finds no matches in the log.