### PR TITLE
Fix ZKP timestamp race condition

### DIFF
--- a/server/decentralizationService.ts
+++ b/server/decentralizationService.ts
@@ -104,11 +104,12 @@ export function generateZKProof(
     .digest('hex');
 
   // Mock proof generation (simulating a zkSNARK)
+  const now = Date.now();
   const proofData = {
     commitment,
     claim,
     publicInput,
-    timestamp: Date.now(),
+    timestamp: now,
     nonce, // Include nonce to ensure different proofs
   };
 
@@ -117,8 +118,8 @@ export function generateZKProof(
     claim,
     proof: Buffer.from(JSON.stringify(proofData)).toString('base64'),
     publicInput,
-    timestamp: Date.now(),
-    expiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000, // 30 days
+    timestamp: now,
+    expiresAt: now + 30 * 24 * 60 * 60 * 1000, // 30 days
   };
 
   zkProofStore.set(proofId, proof);


### PR DESCRIPTION
Fixed a race condition in `server/decentralizationService.ts` where `Date.now()` was called multiple times during ZK proof generation, causing verification failures due to timestamp mismatches. Verified the fix by running the failing test case `server/__tests__/decentralization.test.ts` and the full test suite.

---
*PR created automatically by Jules for task [15287887045311183220](https://jules.google.com/task/15287887045311183220) started by @mrdannyclark82*

## Summary by Sourcery

Bug Fixes:
- Ensure a single captured timestamp is used consistently for ZK proof payload, response timestamp, and expiry calculation to prevent verification mismatches.