### PR TITLE
Update GitHub actions checkout and setup-node versions to v4

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.1
+        uses: actions/checkout@v4
         with:
           clean: true
           lfs: false

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.1
+        uses: actions/checkout@v4
         with:
           clean: true
           lfs: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       CALLBACK_ENDPOINT: ${{ secrets.COPILOT_CALLBACK_ENDPOINT || '' }}
     steps:
       - name: Checkout repository (fetch full history)
-        uses: actions/checkout@v6.0.1
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: false # Explicit no-subs to dodge init
@@ -64,7 +64,7 @@ jobs:
           mkdir -p dynamic/copilot-swe-agent
           echo "Agent dir ready at $(pwd)/dynamic/copilot-swe-agent"
       - name: Use Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v4
         with:
           node-version: 20.x
           cache: 'npm'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         language: ['javascript-typescript', 'python']
     steps:
-      - uses: actions/checkout@v6.0.1
+      - uses: actions/checkout@v4
         with:
           clean: true
           lfs: false

--- a/.github/workflows/copilot-agent-fix.yml
+++ b/.github/workflows/copilot-agent-fix.yml
@@ -11,7 +11,7 @@ jobs:
       CALLBACK_ENDPOINT: ${{ secrets.COPILOT_CALLBACK_ENDPOINT || '' }}
     steps:
       - name: Checkout repository (fetch full history)
-        uses: actions/checkout@v6.0.1
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: false # Explicit no-subs to dodge init
@@ -77,7 +77,7 @@ jobs:
           mkdir -p dynamic/copilot-swe-agent
           echo "Agent dir ready at $(pwd)/dynamic/copilot-swe-agent"
       - name: Use Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v4
         with:
           node-version: 20.x
           cache: 'npm'

--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -16,12 +16,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
       - name: Setup Node.js 20
-        uses: actions/setup-node@v4.0.1
+        uses: actions/setup-node@v4
         with:
           node-version: '20.10.0'
           cache: 'npm'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,12 +29,12 @@ jobs:
       url: https://staging.milla-rayne.app
 
     steps:
-      - uses: actions/checkout@v6.0.1
+      - uses: actions/checkout@v4
         with:
           clean: true
           lfs: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
           node-version: '20.x'
           cache: npm
@@ -73,12 +73,12 @@ jobs:
     needs: []
 
     steps:
-      - uses: actions/checkout@v6.0.1
+      - uses: actions/checkout@v4
         with:
           clean: true
           lfs: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
           node-version: '20.x'
           cache: npm
@@ -111,7 +111,7 @@ jobs:
       url: https://milla-rayne.herokuapp.com
 
     steps:
-      - uses: actions/checkout@v6.0.1
+      - uses: actions/checkout@v4
         with:
           clean: true
           lfs: false
@@ -133,7 +133,7 @@ jobs:
       url: https://milla-rayne.railway.app
 
     steps:
-      - uses: actions/checkout@v6.0.1
+      - uses: actions/checkout@v4
         with:
           clean: true
           lfs: false
@@ -156,12 +156,12 @@ jobs:
       url: https://milla-rayne.example.com
 
     steps:
-      - uses: actions/checkout@v6.0.1
+      - uses: actions/checkout@v4
         with:
           clean: true
           lfs: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
           node-version: '20.x'
 
@@ -213,12 +213,12 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v6.0.1
+      - uses: actions/checkout@v4
         with:
           clean: true
           lfs: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
           node-version: '20.x'
           cache: npm

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -31,7 +31,7 @@ jobs:
         uses: ./.github/actions/mint-token
 
       - name: 'Checkout repository'
-        uses: 'actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8' # ratchet:actions/checkout@v5
+        uses: 'actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8' # ratchet:actions/checkout@v4
 
       - name: 'Run Gemini pull request review'
         uses: 'google-github-actions/run-gemini-cli@v0' # ratchet:exclude

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6.0.1
+      - uses: actions/checkout@v4
         with:
           clean: true
           lfs: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
           node-version: '20.x'
           cache: npm
@@ -41,12 +41,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6.0.1
+      - uses: actions/checkout@v4
         with:
           clean: true
           lfs: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
           node-version: '20.x'
           cache: npm
@@ -63,12 +63,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6.0.1
+      - uses: actions/checkout@v4
         with:
           clean: true
           lfs: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
           node-version: '20.x'
           cache: npm
@@ -97,12 +97,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6.0.1
+      - uses: actions/checkout@v4
         with:
           clean: true
           lfs: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
           node-version: '20.x'
           cache: npm
@@ -126,12 +126,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6.0.1
+      - uses: actions/checkout@v4
         with:
           clean: true
           lfs: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
           node-version: '20.x'
           cache: npm
@@ -155,12 +155,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6.0.1
+      - uses: actions/checkout@v4
         with:
           clean: true
           lfs: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
           node-version: '20.x'
           cache: npm

--- a/.github/workflows/prevent-large-files.yml
+++ b/.github/workflows/prevent-large-files.yml
@@ -8,7 +8,7 @@ jobs:
   check-large-files:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.1
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           clean: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6.0.1
+      - uses: actions/checkout@v4
         with:
           clean: true
           lfs: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
           node-version: '20.x'
           cache: npm
@@ -67,7 +67,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
 
     steps:
-      - uses: actions/checkout@v6.0.1
+      - uses: actions/checkout@v4
         with:
           clean: true
           lfs: false
@@ -119,7 +119,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
 
     steps:
-      - uses: actions/checkout@v6.0.1
+      - uses: actions/checkout@v4
         with:
           clean: true
           lfs: false


### PR DESCRIPTION
Updated all references to `actions/checkout` and `actions/setup-node` in GitHub workflow files to version `@v4`. This fixes workflow execution failures caused by using invalid, non-existent versions like `v6.0.1` and `v6`. Also addressed the associated ratcheting comment in `gemini-review.yml`. Cleaned up unintentionally modified test files from the workspace prior to submission.

---
*PR created automatically by Jules for task [9526724743764536851](https://jules.google.com/task/9526724743764536851) started by @mrdannyclark82*