### PR TITLE
feat: implement message sending logic in chat interface

### DIFF
--- a/.local/state/replit/agent/design_reference/1bb67683-95f1-4724-b7df-1e1333e18257/603df094-e87c-4ddd-ad24-c107aa8d69ae.html
+++ b/.local/state/replit/agent/design_reference/1bb67683-95f1-4724-b7df-1e1333e18257/603df094-e87c-4ddd-ad24-c107aa8d69ae.html
@@ -543,6 +543,17 @@
             ) {
               // TODO: Implement message sending logic
               console.log('Send message:', this.value);
+              const messagePayload = this.value;
+              fetch('/api/chat', {
+                method: 'POST',
+                headers: {
+                  'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ message: messagePayload }),
+              })
+                .then(response => response.json())
+                .then(data => console.log('Message sent successfully:', data))
+                .catch(error => console.error('Error sending message:', error));
               this.value = '';
               this.style.height = 'auto';
               if (wordCountSpan) wordCountSpan.textContent = '0/2000 words';
@@ -559,6 +570,17 @@
             if (textarea && textarea.value.trim()) {
               // TODO: Implement message sending logic
               console.log('Send message:', textarea.value);
+              const messagePayload = textarea.value;
+              fetch('/api/chat', {
+                method: 'POST',
+                headers: {
+                  'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ message: messagePayload }),
+              })
+                .then(response => response.json())
+                .then(data => console.log('Message sent successfully:', data))
+                .catch(error => console.error('Error sending message:', error));
               textarea.value = '';
               textarea.style.height = 'auto';
               if (wordCountSpan) wordCountSpan.textContent = '0/2000 words';


### PR DESCRIPTION
Added fetch calls to '/api/chat' for both the send button click event
and the textarea keydown (Cmd/Ctrl + Enter) event in the chat mockup.
The textarea now correctly sends the payload as JSON { message: value }
and clears upon submission.

---
*PR created automatically by Jules for task [17246355654388232388](https://jules.google.com/task/17246355654388232388) started by @mrdannyclark82*