### PR TITLE
Fix invalid GitHub Actions versions

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -24,7 +24,7 @@ jobs:
           lfs: false
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -21,7 +21,7 @@ jobs:
           lfs: false
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -171,7 +171,7 @@ jobs:
           npm run build
 
       - name: Deploy to VPS via SSH
-        uses: easingthemes/ssh-deploy@v5
+        uses: easingthemes/ssh-deploy@v4
         with:
           SSH_PRIVATE_KEY: ${{ secrets.VPS_SSH_KEY }}
           REMOTE_HOST: ${{ secrets.VPS_HOST }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -82,7 +82,7 @@ jobs:
           NODE_ENV: test
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v4
         if: always()
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,13 +73,13 @@ jobs:
           lfs: false
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist/
 
       - name: Download build info
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v4
         with:
           name: build-info
           path: .
@@ -136,7 +136,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v4
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -147,7 +147,7 @@ jobs:
             type=sha
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v4
         with:
           context: .
           push: true


### PR DESCRIPTION
Fixes failing GitHub Actions workflows by updating actions with invalid version tags (e.g., v5, v6) to the currently valid and supported versions (v4). Affected files include `android-build.yml`, `android-release.yml`, `deploy.yml`, `pr-checks.yml`, and `release.yml`. This addresses issues where workflows fail because specific versions of actions like `actions/setup-java@v5` or `actions/download-artifact@v6` do not exist.

---
*PR created automatically by Jules for task [1141990303994545732](https://jules.google.com/task/1141990303994545732) started by @mrdannyclark82*