### PR TITLE
Fix action version for easingthemes/ssh-deploy from v5 to v5.1.0 in deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -171,7 +171,7 @@ jobs:
           npm run build
 
       - name: Deploy to VPS via SSH
-        uses: easingthemes/ssh-deploy@v5
+        uses: easingthemes/ssh-deploy@v5.1.0
         with:
           SSH_PRIVATE_KEY: ${{ secrets.VPS_SSH_KEY }}
           REMOTE_HOST: ${{ secrets.VPS_HOST }}


### PR DESCRIPTION
Fix action version for easingthemes/ssh-deploy from v5 to v5.1.0 in deploy.yml

The major tag v5 does not exist on the easingthemes/ssh-deploy repository (returns 404). This causes the workflow to fail to resolve the action. Updated it to use the valid v5.1.0 tag instead. All other action versions (v4, v5, v6) in the repository's workflows have been checked and verified as valid.

---
*PR created automatically by Jules for task [16578500319364902784](https://jules.google.com/task/16578500319364902784) started by @mrdannyclark82*