### PR TITLE
fix: resolve test failures in aiDispatcherPriority

### DIFF
--- a/server/__tests__/aiDispatcherPriority.test.ts
+++ b/server/__tests__/aiDispatcherPriority.test.ts
@@ -24,6 +24,9 @@ vi.mock('../memoryService', () => ({
   searchMemoryCore: vi.fn().mockResolvedValue([]),
   getSemanticMemoryContext: vi.fn().mockResolvedValue(''),
 }));
+vi.mock('../youtubeKnowledgeBase', () => ({
+  semanticSearchVideos: vi.fn().mockResolvedValue([]),
+}));
 vi.mock('../xaiTracker', () => ({
   startReasoningSession: vi.fn().mockReturnValue('test-session-id'),
   trackCommandIntent: vi.fn(),
@@ -36,6 +39,7 @@ vi.mock('../storage', () => ({
     getUserPreferredAIModel: vi
       .fn()
       .mockRejectedValue(new Error('No preference')),
+    getUserById: vi.fn().mockResolvedValue({ preferredAiModel: 'minimax' }),
   },
 }));
 


### PR DESCRIPTION
Resolves failing tests in `aiDispatcherPriority.test.ts` caused by missing mocks.
- Mocked `getUserById` in `../storage`
- Mocked `semanticSearchVideos` in `../youtubeKnowledgeBase`

---
*PR created automatically by Jules for task [15827731738827412013](https://jules.google.com/task/15827731738827412013) started by @mrdannyclark82*