### PR TITLE
ci: fix incorrect github action versions in workflows

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -24,7 +24,7 @@ jobs:
           lfs: false
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -21,7 +21,7 @@ jobs:
           lfs: false
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -171,7 +171,7 @@ jobs:
           npm run build
 
       - name: Deploy to VPS via SSH
-        uses: easingthemes/ssh-deploy@v5
+        uses: easingthemes/ssh-deploy@main
         with:
           SSH_PRIVATE_KEY: ${{ secrets.VPS_SSH_KEY }}
           REMOTE_HOST: ${{ secrets.VPS_HOST }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -82,7 +82,7 @@ jobs:
           NODE_ENV: test
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v4
         if: always()
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,13 +73,13 @@ jobs:
           lfs: false
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist/
 
       - name: Download build info
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v4
         with:
           name: build-info
           path: .


### PR DESCRIPTION
Fixes several invalid GitHub Action versions across the `.github/workflows` directory. Action versions like `@v5` for `setup-java` and `codecov`, or `@v6` for `download-artifact` do not exist, which causes workflow runs to fail. These have been updated to `@v4` (and `@main` for ssh-deploy) to restore healthy CI.

---
*PR created automatically by Jules for task [4519187227472519765](https://jules.google.com/task/4519187227472519765) started by @mrdannyclark82*

## Summary by Sourcery

Correct GitHub Actions workflow configurations to use valid action versions and restore CI reliability.

CI:
- Update download-artifact steps in release workflow to use the supported v4 action version.
- Update setup-java steps in Android build and release workflows to use the supported v4 action version.
- Point ssh-deploy in deploy workflow to the maintained main branch instead of an invalid v5 tag.
- Update Codecov action in PR checks workflow to the supported v4 version.