### PR TITLE
Fix invalid GitHub Action versions in CI workflows

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -24,7 +24,7 @@ jobs:
           lfs: false
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -21,7 +21,7 @@ jobs:
           lfs: false
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -171,7 +171,7 @@ jobs:
           npm run build
 
       - name: Deploy to VPS via SSH
-        uses: easingthemes/ssh-deploy@v5
+        uses: easingthemes/ssh-deploy@main
         with:
           SSH_PRIVATE_KEY: ${{ secrets.VPS_SSH_KEY }}
           REMOTE_HOST: ${{ secrets.VPS_HOST }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -82,7 +82,7 @@ jobs:
           NODE_ENV: test
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v4
         if: always()
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,13 +73,13 @@ jobs:
           lfs: false
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist/
 
       - name: Download build info
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v4
         with:
           name: build-info
           path: .


### PR DESCRIPTION
Fixes the issue where GitHub workflows were failing to run due to referencing non-existent or unreleased versions of several standard GitHub actions. 

Downgraded/corrected the following to valid versions:
- `actions/setup-java@v5` -> `v4` (in `android-build.yml`, `android-release.yml`)
- `easingthemes/ssh-deploy@v5` -> `main` (in `deploy.yml`)
- `codecov/codecov-action@v5` -> `v4` (in `pr-checks.yml`)
- `actions/download-artifact@v6` -> `v4` (in `release.yml`)

---
*PR created automatically by Jules for task [594295762915736900](https://jules.google.com/task/594295762915736900) started by @mrdannyclark82*

## Summary by Sourcery

Correct GitHub Actions versions in CI workflows to use valid, existing releases so workflows run reliably.

CI:
- Update actions/setup-java references in Android CI workflows to use the latest valid v4 release.
- Adjust Codecov upload step to use codecov/codecov-action v4 instead of an invalid v5 tag.
- Change artifact download steps in the release workflow to use actions/download-artifact v4.
- Point SSH deployment workflow to the maintained easingthemes/ssh-deploy main branch instead of an invalid v5 tag.