### PR TITLE
fix(workflow): correct attachments format in daily-empire report

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -85,9 +85,7 @@ jobs:
 
             ---
             Automated by Milla-Rayne Daily Empire
-          attachments: |
-            report.md
-            updates.zip
+          attachments: report.md,updates.zip
           priority: normal
 
       - name: Cleanup


### PR DESCRIPTION
Fixes the `daily-empire.yml` GitHub Actions workflow that was failing at the `Send email with report` step. The `dawidd6/action-send-mail` action requires `attachments` to be a comma-separated string rather than a multiline string. The incorrect format caused the step to crash with a "not found" error for a single concatenated file name. This patch corrects the field format to `attachments: report.md,updates.zip`, allowing the step to execute successfully. Also removed extraneous test/build artifacts in the `memory/` directory to ensure clean environment.

---
*PR created automatically by Jules for task [10388171503159835845](https://jules.google.com/task/10388171503159835845) started by @mrdannyclark82*

## Summary by Sourcery

CI:
- Update the daily-empire workflow to pass attachments as a comma-separated string instead of a multiline value for the send-mail step.