### PR TITLE
Fix attachments parameter format in daily-empire workflow

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -85,9 +85,7 @@ jobs:
 
             ---
             Automated by Milla-Rayne Daily Empire
-          attachments: |
-            report.md
-            updates.zip
+          attachments: report.md,updates.zip
           priority: normal
 
       - name: Cleanup


### PR DESCRIPTION
This PR fixes a bug in the `daily-empire.yml` GitHub Actions workflow.

The `dawidd6/action-send-mail` action expects the `attachments` input to be a comma-separated list of file paths. It was previously configured as a multiline YAML string:
```yaml
attachments: |
  report.md
  updates.zip
```
This was causing the workflow to fail when resolving file paths. It has been updated to:
```yaml
attachments: report.md,updates.zip
```

---
*PR created automatically by Jules for task [8382018626464299094](https://jules.google.com/task/8382018626464299094) started by @mrdannyclark82*

## Summary by Sourcery

CI:
- Update the daily-empire workflow to pass attachments to dawidd6/action-send-mail as a comma-separated list of file paths instead of a multiline string.