### PR TITLE
Fix GitHub action versions

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -24,7 +24,7 @@ jobs:
           lfs: false
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -21,7 +21,7 @@ jobs:
           lfs: false
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -171,7 +171,7 @@ jobs:
           npm run build
 
       - name: Deploy to VPS via SSH
-        uses: easingthemes/ssh-deploy@v5
+        uses: easingthemes/ssh-deploy@main
         with:
           SSH_PRIVATE_KEY: ${{ secrets.VPS_SSH_KEY }}
           REMOTE_HOST: ${{ secrets.VPS_HOST }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -82,7 +82,7 @@ jobs:
           NODE_ENV: test
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v4
         if: always()
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,13 +73,13 @@ jobs:
           lfs: false
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist/
 
       - name: Download build info
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v4
         with:
           name: build-info
           path: .


### PR DESCRIPTION
Fixes failing GitHub action runs caused by using non-existent/invalid version tags.

---
*PR created automatically by Jules for task [15895545295715536529](https://jules.google.com/task/15895545295715536529) started by @mrdannyclark82*

## Summary by Sourcery

CI:
- Align GitHub Actions in CI workflows to existing versions for download-artifact, setup-java, ssh-deploy, and codecov actions.