### PR TITLE
Fix attachments format in daily-empire workflow

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -85,9 +85,7 @@ jobs:
 
             ---
             Automated by Milla-Rayne Daily Empire
-          attachments: |
-            report.md
-            updates.zip
+          attachments: report.md,updates.zip
           priority: normal
 
       - name: Cleanup


### PR DESCRIPTION
The `dawidd6/action-send-mail` action expects the `attachments` input to be formatted as a comma-separated list of file paths (e.g., `file1.md,file2.zip`). The previous implementation used a YAML multiline string, which resulted in a single string containing newlines. This caused the step to fail because it could not find a file matching that combined string.

This commit updates `.github/workflows/daily-empire.yml` to correctly format the `attachments` input as a comma-separated string, restoring the functionality of the email reporting step.

---
*PR created automatically by Jules for task [14803605698372327709](https://jules.google.com/task/14803605698372327709) started by @mrdannyclark82*

## Summary by Sourcery

Bug Fixes:
- Ensure the daily-empire workflow passes attachments to dawidd6/action-send-mail as a comma-separated list instead of a multiline string so files are correctly found and sent.