### PR TITLE
Fix daily empire workflow attachments formatting

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -85,9 +85,7 @@ jobs:
 
             ---
             Automated by Milla-Rayne Daily Empire
-          attachments: |
-            report.md
-            updates.zip
+          attachments: report.md,updates.zip
           priority: normal
 
       - name: Cleanup


### PR DESCRIPTION
I checked the github workflows and identified the failure in `Daily Empire Report`. The `dawidd6/action-send-mail` GitHub Action requires the `attachments` parameter to be formatted as a comma-separated list, rather than a multiline YAML string. I modified `.github/workflows/daily-empire.yml` to use `attachments: report.md,updates.zip` to fix the action. I ran the build and tests locally to ensure no other components were broken.

---
*PR created automatically by Jules for task [2195335477464002271](https://jules.google.com/task/2195335477464002271) started by @mrdannyclark82*

## Summary by Sourcery

CI:
- Update the daily-empire GitHub Actions workflow to specify email attachments as a single comma-separated list instead of a multiline value.