### PR TITLE
fix: update attachments syntax in daily-empire workflow

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -85,9 +85,7 @@ jobs:
 
             ---
             Automated by Milla-Rayne Daily Empire
-          attachments: |
-            report.md
-            updates.zip
+          attachments: report.md,updates.zip
           priority: normal
 
       - name: Cleanup


### PR DESCRIPTION
Fixes failing GitHub Action `Daily Empire Report` by updating the `attachments` input of `dawidd6/action-send-mail` step from a multiline YAML string to a comma-separated list.

---
*PR created automatically by Jules for task [3029898879594206538](https://jules.google.com/task/3029898879594206538) started by @mrdannyclark82*

## Summary by Sourcery

CI:
- Adjust the Daily Empire workflow email step to pass attachments as a comma-separated list instead of a multiline string.