### PR TITLE
Fix GitHub Action attachments formatting

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -85,9 +85,7 @@ jobs:
 
             ---
             Automated by Milla-Rayne Daily Empire
-          attachments: |
-            report.md
-            updates.zip
+          attachments: report.md,updates.zip
           priority: normal
 
       - name: Cleanup


### PR DESCRIPTION
Fix GitHub Action attachments formatting

The `dawidd6/action-send-mail` action in the `daily-empire.yml` workflow was failing because it expects `attachments` to be a comma-separated list of paths instead of a multiline string. Updated the formatting to resolve the failure.

---
*PR created automatically by Jules for task [9150011429024980135](https://jules.google.com/task/9150011429024980135) started by @mrdannyclark82*

## Summary by Sourcery

CI:
- Update the daily-empire workflow to pass attachments as a comma-separated list instead of a multiline value for the mail step.