### PR TITLE
Fix attachment syntax in daily empire workflow

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -85,9 +85,7 @@ jobs:
 
             ---
             Automated by Milla-Rayne Daily Empire
-          attachments: |
-            report.md
-            updates.zip
+          attachments: report.md,updates.zip
           priority: normal
 
       - name: Cleanup


### PR DESCRIPTION
Fix attachment syntax in daily empire workflow

The dawidd6/action-send-mail action requires attachments to be formatted as a comma-separated list rather than a multiline YAML string. Changed the format to ensure the daily analysis updates and reports are attached.

---
*PR created automatically by Jules for task [6124010348163781709](https://jules.google.com/task/6124010348163781709) started by @mrdannyclark82*

## Summary by Sourcery

Bug Fixes:
- Fix email attachments configuration in the daily empire workflow so both report and updates files are correctly attached.