### PR TITLE
Fix daily-empire workflow attachments format

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -85,9 +85,7 @@ jobs:
 
             ---
             Automated by Milla-Rayne Daily Empire
-          attachments: |
-            report.md
-            updates.zip
+          attachments: report.md,updates.zip
           priority: normal
 
       - name: Cleanup


### PR DESCRIPTION
Fixes a failure in the `.github/workflows/daily-empire.yml` GitHub action workflow. The `attachments` parameter in the `dawidd6/action-send-mail` step was formatted as a multi-line YAML block, which caused the action to fail because it expects a comma-separated string of file names. This patch changes the `attachments` configuration to correctly use a comma-separated list (`report.md,updates.zip`). Tested to verify it resolves the syntax issue without regressions.

---
*PR created automatically by Jules for task [15749730140640920192](https://jules.google.com/task/15749730140640920192) started by @mrdannyclark82*

## Summary by Sourcery

CI:
- Fix the daily-empire workflow by updating the mail step attachments to a comma-separated list of files.