### PR TITLE
Fix daily empire report email attachment format

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -85,9 +85,7 @@ jobs:
 
             ---
             Automated by Milla-Rayne Daily Empire
-          attachments: |
-            report.md
-            updates.zip
+          attachments: report.md,updates.zip
           priority: normal
 
       - name: Cleanup


### PR DESCRIPTION
Changes the `attachments` parameter in the `Send email with report` step of `.github/workflows/daily-empire.yml` from a YAML multiline string to a comma-separated list (`report.md,updates.zip`) as required by the `dawidd6/action-send-mail` action. This resolves the failure in the Daily Empire Report workflow run.

---
*PR created automatically by Jules for task [10403225481638493160](https://jules.google.com/task/10403225481638493160) started by @mrdannyclark82*

## Summary by Sourcery

Build:
- Update the daily-empire GitHub Actions workflow to pass attachments as a comma-separated list instead of a multiline string.