### PR TITLE
Fix failing daily empire report workflow attachments syntax

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -85,9 +85,7 @@ jobs:
 
             ---
             Automated by Milla-Rayne Daily Empire
-          attachments: |
-            report.md
-            updates.zip
+          attachments: report.md,updates.zip
           priority: normal
 
       - name: Cleanup


### PR DESCRIPTION
Fixes the "Daily Empire Report" GitHub Actions workflow. The `Send email with report` step was failing because the `dawidd6/action-send-mail` action expects the `attachments` input to be a comma-separated string (`report.md,updates.zip`) instead of a multiline YAML block. This update resolves the syntax issue to ensure the workflow can successfully email the generated reports.

---
*PR created automatically by Jules for task [5823068153498093027](https://jules.google.com/task/5823068153498093027) started by @mrdannyclark82*

## Summary by Sourcery

Fix the Daily Empire GitHub Actions workflow so that email reports are sent with correctly formatted attachments.

Bug Fixes:
- Correct the attachments configuration for the email-sending step so the workflow no longer fails when sending the daily report.

CI:
- Update the daily-empire workflow to pass attachments as a comma-separated string to the mail action instead of a multiline block.