### PR TITLE
Fix: Format action-send-mail attachments input as comma-separated list

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -85,9 +85,7 @@ jobs:
 
             ---
             Automated by Milla-Rayne Daily Empire
-          attachments: |
-            report.md
-            updates.zip
+          attachments: report.md,updates.zip
           priority: normal
 
       - name: Cleanup


### PR DESCRIPTION
Fix: format dawidd6/action-send-mail attachments input

The `dawidd6/action-send-mail` GitHub action expects the `attachments` input to be formatted as a comma-separated list of file paths. A multi-line YAML string causes the action to fail because it treats the multiline block as a single, malformed filename.

This updates the `attachments` input in `.github/workflows/daily-empire.yml` from a multiline format to `report.md,updates.zip` to fix workflow failures.

---
*PR created automatically by Jules for task [17067266008037078144](https://jules.google.com/task/17067266008037078144) started by @mrdannyclark82*

## Summary by Sourcery

CI:
- Update the daily-empire GitHub Actions workflow to pass attachments as a single comma-separated string instead of a multiline block.