### PR TITLE
Fix attachments syntax in Daily Empire Report workflow

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -85,9 +85,7 @@ jobs:
 
             ---
             Automated by Milla-Rayne Daily Empire
-          attachments: |
-            report.md
-            updates.zip
+          attachments: report.md,updates.zip
           priority: normal
 
       - name: Cleanup


### PR DESCRIPTION
This commit fixes the syntax for the attachments parameter in `.github/workflows/daily-empire.yml`.

The workflow previously used a multiline YAML block, but `dawidd6/action-send-mail` requires a comma-separated list. This change updates `attachments` to `report.md,updates.zip`, which should resolve the recent workflow failures in the action run.

---
*PR created automatically by Jules for task [9307807750263822786](https://jules.google.com/task/9307807750263822786) started by @mrdannyclark82*

## Summary by Sourcery

CI:
- Update the daily-empire GitHub Actions workflow to pass attachments as a comma-separated list instead of a multiline block to the mail-sending action.