### PR TITLE
Fix daily-empire workflow attachments

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -85,9 +85,7 @@ jobs:
 
             ---
             Automated by Milla-Rayne Daily Empire
-          attachments: |
-            report.md
-            updates.zip
+          attachments: report.md,updates.zip
           priority: normal
 
       - name: Cleanup


### PR DESCRIPTION
This commit fixes the `daily-empire.yml` workflow by formatting the `attachments` array as a comma-separated string instead of a multiline YAML array, which causes the `dawidd6/action-send-mail` GitHub action to fail. It also regenerates `package-lock.json` to be in sync.

---
*PR created automatically by Jules for task [9139687133846786757](https://jules.google.com/task/9139687133846786757) started by @mrdannyclark82*

## Summary by Sourcery

Fix the daily-empire GitHub Actions workflow email step to use a comma-separated attachments string compatible with the mail-sending action.

Bug Fixes:
- Correct email attachments configuration in the daily-empire workflow so the send-mail action no longer fails.

CI:
- Adjust daily-empire workflow configuration to pass attachments as a comma-separated string instead of a multiline YAML array.