### PR TITLE
Fix attachments format in daily-empire workflow

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -85,9 +85,7 @@ jobs:
 
             ---
             Automated by Milla-Rayne Daily Empire
-          attachments: |
-            report.md
-            updates.zip
+          attachments: report.md,updates.zip
           priority: normal
 
       - name: Cleanup


### PR DESCRIPTION
Fix attachments format in daily-empire workflow

The dawidd6/action-send-mail action requires the `attachments` input
to be a comma-separated list of strings, rather than a multi-line YAML
string. Changed the format to ensure the daily empire report email
is successfully sent with attachments.

---
*PR created automatically by Jules for task [5052559140628968291](https://jules.google.com/task/5052559140628968291) started by @mrdannyclark82*

## Summary by Sourcery

Bug Fixes:
- Fix email attachment configuration in the daily-empire workflow by switching from a multiline YAML block to a comma-separated attachments list.