### PR TITLE
ci: fix github actions upload artifact version

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -55,7 +55,7 @@ jobs:
           echo "✓ All outputs generated successfully"
 
       - name: Upload report as artifact
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v4
         with:
           name: daily-report-${{ github.run_number }}
           path: |


### PR DESCRIPTION
Fixes hardcoded patch version for `upload-artifact` in the daily empire workflow. Note that actual workflow failures occurring across the repository at this time are due to a GitHub account billing lock, which prevents jobs from starting.

---
*PR created automatically by Jules for task [4890754402217629334](https://jules.google.com/task/4890754402217629334) started by @mrdannyclark82*

## Summary by Sourcery

CI:
- Relax the upload-artifact action reference in the daily empire workflow from a specific patch version to the v4 major tag.