### PR TITLE
Fix Action Send Mail Warning

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -68,7 +68,6 @@ jobs:
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
Fixes a minor configuration warning in the daily-empire workflow. The workflow failure itself is due to invalid email credentials which the user needs to update in their repository secrets.

---
*PR created automatically by Jules for task [2744444652673377770](https://jules.google.com/task/2744444652673377770) started by @mrdannyclark82*

## Summary by Sourcery

CI:
- Update the daily-empire workflow email step by removing the explicit STARTTLS configuration from the mail action.