### PR TITLE
Fix action-send-mail inputs

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -68,7 +68,6 @@ jobs:
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
Removed the unsupported `starttls` parameter from the `dawidd6/action-send-mail` action in `.github/workflows/daily-empire.yml`. This parameter was causing an `Unexpected input` warning. The root cause of the workflow failure (invalid Gmail SMTP password) has been communicated to the user so they can update the repository secret with a Google App Password.

---
*PR created automatically by Jules for task [15574140291377894316](https://jules.google.com/task/15574140291377894316) started by @mrdannyclark82*

## Summary by Sourcery

CI:
- Remove the unsupported starttls input from the daily-empire email workflow to align with the action-send-mail configuration.