### PR TITLE
Fix Daily Empire Report workflow failure

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -68,7 +68,6 @@ jobs:
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
Removed the `starttls` parameter from the `dawidd6/action-send-mail` action step in `.github/workflows/daily-empire.yml`. This parameter was invalid, causing the "Daily Empire Report" workflow to fail, and isn't supported by the action which relies on nodemailer to upgrade port 587 connections automatically.

---
*PR created automatically by Jules for task [1094662807636851504](https://jules.google.com/task/1094662807636851504) started by @mrdannyclark82*

## Summary by Sourcery

CI:
- Remove unsupported starttls parameter from the daily-empire GitHub Actions workflow email step to prevent workflow failures.