### PR TITLE
Fix daily-empire workflow actions and inputs

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -55,7 +55,7 @@ jobs:
           echo "✓ All outputs generated successfully"
 
       - name: Upload report as artifact
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v4
         with:
           name: daily-report-${{ github.run_number }}
           path: |
@@ -64,11 +64,10 @@ jobs:
           retention-days: 30
 
       - name: Send email with report
-        uses: dawidd6/action-send-mail@v3.12.0
+        uses: dawidd6/action-send-mail@v3
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
Updates GitHub action versions to their major tags and removes unsupported parameters from the mail action in `.github/workflows/daily-empire.yml`.

Note: The user has been instructed to update the `EMAIL_PASS` secret to a Google App Password, as that is required for SMTP authentication and was failing with `535-5.7.8 Username and Password not accepted`.

---
*PR created automatically by Jules for task [1114056097840171452](https://jules.google.com/task/1114056097840171452) started by @mrdannyclark82*

## Summary by Sourcery

Update the daily-empire GitHub workflow to use major-tagged action versions and align email-sending configuration with the mail action’s supported parameters.

Build:
- Switch the upload-artifact action in the daily-empire workflow to the v4 major tag.
- Switch the send-mail action in the daily-empire workflow to the v3 major tag and remove an unsupported TLS-related parameter.