### PR TITLE
fix: update action versions and resolve invalid input in daily-empire workflow

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -55,7 +55,7 @@ jobs:
           echo "✓ All outputs generated successfully"
 
       - name: Upload report as artifact
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v4
         with:
           name: daily-report-${{ github.run_number }}
           path: |
@@ -64,11 +64,10 @@ jobs:
           retention-days: 30
 
       - name: Send email with report
-        uses: dawidd6/action-send-mail@v3.12.0
+        uses: dawidd6/action-send-mail@v3
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
This PR addresses the failures in the `.github/workflows/daily-empire.yml` `daily-analysis` job.

- Replaced outdated, specific action version tags (`v4.0.0`, `v3.12.0`) with major version tags (`v4`, `v3`) to ensure non-breaking patches are applied automatically.
- Removed the `starttls` input from `dawidd6/action-send-mail`, as it is not an accepted input parameter and was causing job failures. Port 587 inherently supports STARTTLS without requiring this flag.

---
*PR created automatically by Jules for task [13944920427312149677](https://jules.google.com/task/13944920427312149677) started by @mrdannyclark82*

## Summary by Sourcery

Update the daily empire GitHub Actions workflow to use major action versions and fix invalid email action configuration.

Build:
- Relax action version pins in the daily-empire workflow to use major versions for upload-artifact and action-send-mail.
- Remove the unsupported starttls input from the email sending step to prevent workflow failures.