### PR TITLE
Fix daily empire workflow warnings

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -68,7 +68,6 @@ jobs:
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
Removed the unsupported `starttls` parameter from the `dawidd6/action-send-mail` step in `.github/workflows/daily-empire.yml`.
This resolves a warning in the GitHub Actions run.
Also notified the user that the workflow's main failure is due to bad SMTP credentials and they must generate a Google App Password for the `EMAIL_PASS` secret.

---
*PR created automatically by Jules for task [4283850253040666821](https://jules.google.com/task/4283850253040666821) started by @mrdannyclark82*

## Summary by Sourcery

CI:
- Remove the deprecated starttls parameter from the daily-empire mail-sending step to silence GitHub Actions warnings.