### PR TITLE
ci: fix daily empire workflow configuration

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -55,7 +55,7 @@ jobs:
           echo "✓ All outputs generated successfully"
 
       - name: Upload report as artifact
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v4
         with:
           name: daily-report-${{ github.run_number }}
           path: |
@@ -64,11 +64,10 @@ jobs:
           retention-days: 30
 
       - name: Send email with report
-        uses: dawidd6/action-send-mail@v3.12.0
+        uses: dawidd6/action-send-mail@v3
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
Updates hardcoded action version numbers in the Daily Empire workflow to use major version tags, aligning with repository conventions. It also removes the invalid `starttls: true` parameter from the `dawidd6/action-send-mail` step, which was causing the workflow to fail.

---
*PR created automatically by Jules for task [3573116523159583109](https://jules.google.com/task/3573116523159583109) started by @mrdannyclark82*

## Summary by Sourcery

Align Daily Empire GitHub Actions workflow with repository conventions for action versions and fix configuration causing workflow failures.

CI:
- Update Daily Empire workflow to use major version tags for upload-artifact and send-mail actions instead of pinned patch versions.
- Remove the invalid starttls parameter from the send-mail action configuration to prevent workflow failures.