### PR TITLE
Fix daily empire workflow actions versions and unsupported parameter

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -55,7 +55,7 @@ jobs:
           echo "✓ All outputs generated successfully"
 
       - name: Upload report as artifact
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v4
         with:
           name: daily-report-${{ github.run_number }}
           path: |
@@ -64,11 +64,10 @@ jobs:
           retention-days: 30
 
       - name: Send email with report
-        uses: dawidd6/action-send-mail@v3.12.0
+        uses: dawidd6/action-send-mail@v3
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
Fixed the failing `Daily Empire Report` workflow by updating the `actions/upload-artifact` and `dawidd6/action-send-mail` action versions to major versions (v4 and v3, respectively). Also removed the unsupported `starttls: true` parameter from the send-mail action step which was causing the "Send email with report" step to fail.

---
*PR created automatically by Jules for task [1121120662627972063](https://jules.google.com/task/1121120662627972063) started by @mrdannyclark82*

## Summary by Sourcery

Update the Daily Empire report GitHub Actions workflow to use supported action versions and configuration so the email step no longer fails.

CI:
- Bump actions/upload-artifact and dawidd6/action-send-mail to their latest major versions in the daily-empire workflow.
- Remove the unsupported starttls parameter from the send-mail step to restore compatibility with the updated action.