### PR TITLE
Fix GitHub Action Workflow Warnings

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -55,7 +55,7 @@ jobs:
           echo "✓ All outputs generated successfully"
 
       - name: Upload report as artifact
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v4
         with:
           name: daily-report-${{ github.run_number }}
           path: |
@@ -64,11 +64,10 @@ jobs:
           retention-days: 30
 
       - name: Send email with report
-        uses: dawidd6/action-send-mail@v3.12.0
+        uses: dawidd6/action-send-mail@v3
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
This commit addresses Node 20 deprecation warnings in the Daily Empire Report GitHub workflow by updating the `upload-artifact` and `action-send-mail` actions to their latest major versions. It also removes an unsupported `starttls` parameter from the email action, which was causing an 'Unexpected input' warning.

---
*PR created automatically by Jules for task [13369975820184981372](https://jules.google.com/task/13369975820184981372) started by @mrdannyclark82*

## Summary by Sourcery

Update the Daily Empire Report GitHub workflow to remove deprecation warnings and unsupported inputs when running on Node 20.

CI:
- Bump actions/upload-artifact to the latest v4 major tag in the Daily Empire Report workflow.
- Bump dawidd6/action-send-mail to the latest v3 major tag and drop the unsupported starttls input to resolve GitHub Action warnings.