### PR TITLE
ci: fix daily-empire workflow failures

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -55,7 +55,7 @@ jobs:
           echo "✓ All outputs generated successfully"
 
       - name: Upload report as artifact
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v4
         with:
           name: daily-report-${{ github.run_number }}
           path: |
@@ -64,11 +64,10 @@ jobs:
           retention-days: 30
 
       - name: Send email with report
-        uses: dawidd6/action-send-mail@v3.12.0
+        uses: dawidd6/action-send-mail@v3
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
This PR addresses failing GitHub Action workflows, specifically within `.github/workflows/daily-empire.yml`.

Changes included:
- Replaced the hardcoded minor patch version `actions/upload-artifact@v4.0.0` with the major tag `v4`.
- Updated `dawidd6/action-send-mail` to the major tag `v3`.
- Removed the invalid `starttls: true` parameter from `dawidd6/action-send-mail`, which was causing workflow warnings/failures, as STARTTLS is automatically configured for port 587.

---
*PR created automatically by Jules for task [17018869589896465863](https://jules.google.com/task/17018869589896465863) started by @mrdannyclark82*

## Summary by Sourcery

Update the daily-empire GitHub Actions workflow to use major-version tags for actions and remove a misconfigured email option to restore successful runs.

Build:
- Switch actions/upload-artifact usage to the v4 major tag in the daily-empire workflow.
- Update dawidd6/action-send-mail to the v3 major tag and drop the invalid starttls parameter in the daily-empire workflow.