### PR TITLE
Fix GitHub Actions workflow failures

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,13 +7,6 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: 'deps(npm)'
-  - package-ecosystem: 'pip'
-    directory: '/'
-    schedule:
-      interval: 'weekly'
-    open-pull-requests-limit: 3
-    commit-message:
-      prefix: 'deps(pip)'
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:

--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -68,7 +68,6 @@ jobs:
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
Fixes failures in the Dependabot and Daily Empire Report workflows by correcting invalid configurations.

---
*PR created automatically by Jules for task [4559233762940959243](https://jules.google.com/task/4559233762940959243) started by @mrdannyclark82*

## Summary by Sourcery

Correct configuration issues in Dependabot and the Daily Empire report GitHub Actions workflow to prevent workflow failures.

CI:
- Remove unsupported pip ecosystem configuration from Dependabot to align with valid update settings.
- Adjust Daily Empire email step configuration by dropping the explicit STARTTLS flag to fix the workflow run.