### PR TITLE
Fix daily empire workflow email step parameters and action versions

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -55,7 +55,7 @@ jobs:
           echo "✓ All outputs generated successfully"
 
       - name: Upload report as artifact
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v4
         with:
           name: daily-report-${{ github.run_number }}
           path: |
@@ -64,11 +64,10 @@ jobs:
           retention-days: 30
 
       - name: Send email with report
-        uses: dawidd6/action-send-mail@v3.12.0
+        uses: dawidd6/action-send-mail@v3
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
This pull request addresses a failure in the Daily Empire Report workflow by removing an invalid `starttls` parameter from the email sending step and updating action versions to use major tags.

---
*PR created automatically by Jules for task [3666818990245640174](https://jules.google.com/task/3666818990245640174) started by @mrdannyclark82*

## Summary by Sourcery

Update the daily empire workflow email step configuration and standardize action versions to use major tags.

Bug Fixes:
- Remove invalid starttls parameter from the email sending step to fix the Daily Empire Report workflow failure.

Enhancements:
- Update upload-artifact and send-mail GitHub Actions to use major version tags in the daily empire workflow.

CI:
- Align GitHub Actions versions in the daily empire workflow to stable major tags.