### PR TITLE
Fix workflow config warning

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -68,7 +68,6 @@ jobs:
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
Removed the unsupported `starttls` parameter from `.github/workflows/daily-empire.yml`.

---
*PR created automatically by Jules for task [14860235130200431501](https://jules.google.com/task/14860235130200431501) started by @mrdannyclark82*

## Summary by Sourcery

CI:
- Remove unsupported starttls parameter from the daily-empire workflow email configuration to eliminate workflow warnings.