### PR TITLE
Fix daily empire workflow parameters

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -55,7 +55,7 @@ jobs:
           echo "✓ All outputs generated successfully"
 
       - name: Upload report as artifact
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v4
         with:
           name: daily-report-${{ github.run_number }}
           path: |
@@ -64,11 +64,10 @@ jobs:
           retention-days: 30
 
       - name: Send email with report
-        uses: dawidd6/action-send-mail@v3.12.0
+        uses: dawidd6/action-send-mail@v3
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
Removed `starttls: true` from `.github/workflows/daily-empire.yml` and updated GitHub Actions versions. In parallel, informed the user of the external secret update required for SMTP auth.

---
*PR created automatically by Jules for task [13780876183384853152](https://jules.google.com/task/13780876183384853152) started by @mrdannyclark82*

## Summary by Sourcery

Update the daily Empire GitHub Actions workflow to use major versions of dependencies and adjust email step configuration.

CI:
- Bump actions/upload-artifact from v4.0.0 to the v4 major tag in the daily Empire workflow.
- Bump dawidd6/action-send-mail from v3.12.0 to the v3 major tag and remove the explicit STARTTLS flag in the email step of the daily Empire workflow.