### PR TITLE
Fix Daily Empire workflow configuration

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -55,7 +55,7 @@ jobs:
           echo "✓ All outputs generated successfully"
 
       - name: Upload report as artifact
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v4
         with:
           name: daily-report-${{ github.run_number }}
           path: |
@@ -64,11 +64,10 @@ jobs:
           retention-days: 30
 
       - name: Send email with report
-        uses: dawidd6/action-send-mail@v3.12.0
+        uses: dawidd6/action-send-mail@v3
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
Fixes workflow warnings and schema errors for the Daily Empire Report. Instructed user to update the `EMAIL_PASS` secret to a Google App Password to resolve the final SMTP authentication failure.

---
*PR created automatically by Jules for task [7882512712928932704](https://jules.google.com/task/7882512712928932704) started by @mrdannyclark82*

## Summary by Sourcery

Update Daily Empire workflow configuration to align with current GitHub Actions and email action versions.

CI:
- Relax version pinning for upload-artifact action to the v4 major tag in the Daily Empire workflow.
- Relax version pinning for the email send action to the v3 major tag and rely on default TLS settings in the Daily Empire workflow.