### PR TITLE
Fix Daily Empire workflow and diagnose email failure

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -55,7 +55,7 @@ jobs:
           echo "✓ All outputs generated successfully"
 
       - name: Upload report as artifact
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v4
         with:
           name: daily-report-${{ github.run_number }}
           path: |
@@ -64,11 +64,10 @@ jobs:
           retention-days: 30
 
       - name: Send email with report
-        uses: dawidd6/action-send-mail@v3.12.0
+        uses: dawidd6/action-send-mail@v3
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
Fixed the "Daily Empire Report" GitHub Actions workflow. Removed an invalid input parameter that was causing warnings and updated action versions to avoid deprecation warnings. Identified external authentication issue requiring user action.

---
*PR created automatically by Jules for task [16710572952833098823](https://jules.google.com/task/16710572952833098823) started by @mrdannyclark82*

## Summary by Sourcery

Update the Daily Empire GitHub Actions workflow to use current action versions and align email step configuration with the action’s supported inputs.

CI:
- Bump actions/upload-artifact in the Daily Empire workflow to the latest v4 tag.
- Bump dawidd6/action-send-mail in the Daily Empire workflow to the latest v3 tag and remove an unsupported email configuration input.