### PR TITLE
Fix Daily Empire workflow warnings

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -55,7 +55,7 @@ jobs:
           echo "✓ All outputs generated successfully"
 
       - name: Upload report as artifact
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v4
         with:
           name: daily-report-${{ github.run_number }}
           path: |
@@ -68,7 +68,6 @@ jobs:
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
This PR addresses warnings found in the `Daily Empire Report` workflow. It updates `actions/upload-artifact` to a major version tag and removes an invalid parameter from the email sending step. I have also left a message for the user explaining that the root cause of the workflow failure is due to Google's SMTP rejecting standard account passwords, and that they need to generate and set an App Password for the `EMAIL_PASS` secret.

---
*PR created automatically by Jules for task [8070315739249589480](https://jules.google.com/task/8070315739249589480) started by @mrdannyclark82*

## Summary by Sourcery

Update the Daily Empire GitHub Actions workflow to resolve warnings from artifact upload and email steps.

Build:
- Switch the Daily Empire workflow to use the major version tag of actions/upload-artifact instead of a specific patch version.
- Remove the unsupported starttls parameter from the email sending step in the Daily Empire workflow.