### PR TITLE
Fix workflow failures (Dependabot and Email Action)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,13 +7,6 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: 'deps(npm)'
-  - package-ecosystem: 'pip'
-    directory: '/'
-    schedule:
-      interval: 'weekly'
-    open-pull-requests-limit: 3
-    commit-message:
-      prefix: 'deps(pip)'
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:

--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -68,7 +68,6 @@ jobs:
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
Fixes recent workflow failures:
1. The Dependabot workflow was failing because it was trying to scan for `pip` packages in the root, but no Python dependency files exist there. I removed `pip` from `.github/dependabot.yml`.
2. The `daily-empire` workflow was producing a warning (and potentially contributing to failures) due to an unexpected `starttls: true` parameter being passed to `dawidd6/action-send-mail`. I removed this invalid input.

Additionally, I noticed the underlying reason the `daily-empire` report email failed to send was an SMTP authentication failure (`535-5.7.8 Username and Password not accepted`). Since Google SMTP requires an App Password instead of a standard account password, I have informed the user to update their `EMAIL_PASS` repository secret accordingly.

---
*PR created automatically by Jules for task [10291443334784006745](https://jules.google.com/task/10291443334784006745) started by @mrdannyclark82*

## Summary by Sourcery

Resolve GitHub workflow issues by adjusting Dependabot configuration and fixing an email-sending workflow input.

Build:
- Update Dependabot configuration to stop scanning for non-existent root-level pip dependencies.

CI:
- Remove invalid starttls parameter from the daily-empire email workflow to prevent action warnings and failures.