### PR TITLE
Fix GitHub Actions workflow syntax and checkout errors

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -68,7 +68,6 @@ jobs:
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'

--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -69,6 +69,9 @@ jobs:
       additional_context: '${{ steps.extract_command.outputs.additional_context }}'
       issue_number: '${{ github.event.pull_request.number || github.event.issue.number }}'
     steps:
+      - name: 'Checkout repository'
+        uses: actions/checkout@v4
+
       - name: 'Mint identity token'
         id: 'mint_identity_token'
         uses: ./.github/actions/mint-token
@@ -171,6 +174,9 @@ jobs:
       issues: 'write'
       pull-requests: 'write'
     steps:
+      - name: 'Checkout repository'
+        uses: actions/checkout@v4
+
       - name: 'Mint identity token'
         id: 'mint_identity_token'
         uses: ./.github/actions/mint-token


### PR DESCRIPTION
This commit fixes the syntax errors and missing checkout steps that were causing the Daily Empire and Gemini Dispatch GitHub Actions workflows to fail. Note: Further workflow failures related to invalid email credentials and insufficient Claude API credits require manual user intervention.

---
*PR created automatically by Jules for task [2989378888036872650](https://jules.google.com/task/2989378888036872650) started by @mrdannyclark82*

## Summary by Sourcery

Fix GitHub Actions workflow configuration so Gemini Dispatch and Daily Empire jobs run correctly.

CI:
- Add missing repository checkout steps to Gemini Dispatch workflow jobs that require repo context.
- Adjust Daily Empire email step configuration by removing the explicit STARTTLS setting that broke the workflow.