### PR TITLE
ci: remove unsupported starttls parameter from action-send-mail

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -68,7 +68,6 @@ jobs:
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
I have analyzed the repository workflows. Currently, the "Daily Empire Report" workflow is failing. The specific error in the logs is `Invalid login: 535-5.7.8 Username and Password not accepted` for the Gmail SMTP server. This requires manual intervention: a Google App Password needs to be generated for the Gmail account and the `EMAIL_PASS` repository secret must be updated with that App Password.

In the meantime, I have created a commit to fix a minor misconfiguration in the same workflow. The `dawidd6/action-send-mail` step was using an unsupported `starttls: true` parameter, causing an `Unexpected input` warning in the action logs. This has been removed. The action natively uses STARTTLS when port 587 is specified. Tests have been run and verified.

---
*PR created automatically by Jules for task [9992516025863932933](https://jules.google.com/task/9992516025863932933) started by @mrdannyclark82*

## Summary by Sourcery

CI:
- Remove the unsupported starttls input from the dawidd6/action-send-mail step in the daily-empire workflow to eliminate action input warnings.