### PR TITLE
Fix Daily Empire workflow warning

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -68,7 +68,6 @@ jobs:
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
Removed unsupported `starttls` parameter from the email action in `.github/workflows/daily-empire.yml` to clear workflow warnings. Instructed user to update their `EMAIL_PASS` secret with a Google App Password to resolve the underlying SMTP "Invalid login" error.

---
*PR created automatically by Jules for task [7031137571350390456](https://jules.google.com/task/7031137571350390456) started by @mrdannyclark82*

## Summary by Sourcery

CI:
- Update the Daily Empire workflow email step by removing the unsupported starttls parameter from the SMTP configuration.