### PR TITLE
Fix daily empire workflow parameters and diagnose failure

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -68,7 +68,6 @@ jobs:
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
Fixed an invalid parameter causing warnings in the `Daily Empire Report` workflow and analyzed the primary root cause for its failure (invalid Google SMTP credentials). The user has been instructed to update the `EMAIL_PASS` secret with a Google App Password.

---
*PR created automatically by Jules for task [10531207751595773951](https://jules.google.com/task/10531207751595773951) started by @mrdannyclark82*

## Summary by Sourcery

Build:
- Update the Daily Empire Report GitHub Actions workflow email step by dropping the unsupported starttls parameter from the SMTP configuration.