### PR TITLE
Fix Daily Empire workflow invalid input

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -68,7 +68,6 @@ jobs:
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
Fixes the "Unexpected input(s) 'starttls'" error in the Daily Empire Report workflow. Note: The user still needs to update their `EMAIL_PASS` secret with a Google App Password to fully resolve the workflow failures.

---
*PR created automatically by Jules for task [1105877748966886655](https://jules.google.com/task/1105877748966886655) started by @mrdannyclark82*

## Summary by Sourcery

CI:
- Remove the deprecated 'starttls' parameter from the Daily Empire email workflow configuration to satisfy the current action inputs.