### PR TITLE
Fix Daily Empire Report Workflow Failure

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -68,7 +68,6 @@ jobs:
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
Removes the `starttls: true` parameter from the `dawidd6/action-send-mail` step in the `daily-empire.yml` workflow. This resolves a failure in the 'Send email with report' job, as `starttls` is not a valid input parameter for this action and causes it to fail. The action handles secure connections implicitly on port 587.

---
*PR created automatically by Jules for task [4874569055754043534](https://jules.google.com/task/4874569055754043534) started by @mrdannyclark82*

## Summary by Sourcery

CI:
- Update the daily-empire GitHub Actions workflow mail step to remove an invalid starttls parameter from the send-mail action configuration.