### PR TITLE
Fix daily-empire workflow syntax and notify user of secret issue

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -55,7 +55,7 @@ jobs:
           echo "✓ All outputs generated successfully"
 
       - name: Upload report as artifact
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v4
         with:
           name: daily-report-${{ github.run_number }}
           path: |
@@ -68,7 +68,6 @@ jobs:
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
This pull request cleans up the `.github/workflows/daily-empire.yml` file by removing an unsupported parameter (`starttls`) from the send-mail action, which was causing workflow warnings. It also updates the upload-artifact action version.

Please note: As communicated directly via message, the root cause of the workflow failure is an SMTP authentication error (535-5.7.8 Username and Password not accepted). To fully resolve this, the repository owner must update the `EMAIL_PASS` GitHub Secret to use a Google App Password rather than their standard account password.

---
*PR created automatically by Jules for task [715088314721096784](https://jules.google.com/task/715088314721096784) started by @mrdannyclark82*

## Summary by Sourcery

Update the daily-empire GitHub Actions workflow to use the latest v4 upload-artifact action and remove an unsupported parameter from the mail-sending step to eliminate workflow warnings.

CI:
- Bump actions/upload-artifact in the daily-empire workflow to the v4 major tag.
- Remove the unsupported starttls parameter from the send-mail step in the daily-empire workflow configuration.