### PR TITLE
Fix workflow configuration and action versions

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -55,7 +55,7 @@ jobs:
           echo "✓ All outputs generated successfully"
 
       - name: Upload report as artifact
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v4
         with:
           name: daily-report-${{ github.run_number }}
           path: |
@@ -64,11 +64,10 @@ jobs:
           retention-days: 30
 
       - name: Send email with report
-        uses: dawidd6/action-send-mail@v3.12.0
+        uses: dawidd6/action-send-mail@v3
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'

--- a/.github/workflows/gemini-scheduled-triage.yml
+++ b/.github/workflows/gemini-scheduled-triage.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - name: 'Get repository labels'
         id: 'get_labels'
-        uses: 'actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea' # ratchet:actions/github-script@v7.0.1
+        uses: 'actions/github-script@v7' # ratchet:actions/github-script@v7.0.1
         with:
           # NOTE: we intentionally do not use the minted token. The default
           # GITHUB_TOKEN provided by the action has enough permissions to read
@@ -254,7 +254,7 @@ jobs:
         env:
           AVAILABLE_LABELS: '${{ needs.triage.outputs.available_labels }}'
           TRIAGED_ISSUES: '${{ needs.triage.outputs.triaged_issues }}'
-        uses: 'actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea' # ratchet:actions/github-script@v7.0.1
+        uses: 'actions/github-script@v7' # ratchet:actions/github-script@v7.0.1
         with:
           # Use the provided token so that the "gemini-cli" is the actor in the
           # log for what changed the labels.

--- a/.github/workflows/gemini-triage.yml
+++ b/.github/workflows/gemini-triage.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - name: 'Get repository labels'
         id: 'get_labels'
-        uses: 'actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea' # ratchet:actions/github-script@v7.0.1
+        uses: 'actions/github-script@v7' # ratchet:actions/github-script@v7.0.1
         with:
           # NOTE: we intentionally do not use the given token. The default
           # GITHUB_TOKEN provided by the action has enough permissions to read
@@ -163,7 +163,7 @@ jobs:
           ISSUE_NUMBER: '${{ github.event.issue.number }}'
           AVAILABLE_LABELS: '${{ needs.triage.outputs.available_labels }}'
           SELECTED_LABELS: '${{ needs.triage.outputs.selected_labels }}'
-        uses: 'actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea' # ratchet:actions/github-script@v7.0.1
+        uses: 'actions/github-script@v7' # ratchet:actions/github-script@v7.0.1
         with:
           # Use the provided token so that the "gemini-cli" is the actor in the
           # log for what changed the labels.


### PR DESCRIPTION
Resolves syntax errors and deprecation warnings in repository workflows. In addition to these changes, the `EMAIL_PASS` repository secret must be manually updated to use a Google App Password to fully resolve the Daily Empire Report authentication error.

---
*PR created automatically by Jules for task [5486725433788477960](https://jules.google.com/task/5486725433788477960) started by @mrdannyclark82*

## Summary by Sourcery

Update GitHub Actions workflows to use supported action version tags and clean up deprecated configuration options.

Enhancements:
- Relax action versions in workflows to the latest v3/v4 major tags for upload-artifact, send-mail, and github-script actions.
- Remove obsolete SMTP configuration in the daily report email step to align with current action defaults.