### PR TITLE
ci: remove invalid starttls parameter from email action

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -68,7 +68,6 @@ jobs:
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
Fixes an "Unexpected input(s) 'starttls'" warning in the `Daily Empire Report` workflow by removing the unrecognized parameter. The user has also been notified to verify their `EMAIL_PASS` secret to resolve a separate SMTP authentication failure.

---
*PR created automatically by Jules for task [4218792741087603141](https://jules.google.com/task/4218792741087603141) started by @mrdannyclark82*