### PR TITLE
ci: fix daily empire workflow actions and parameters

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -55,7 +55,7 @@ jobs:
           echo "✓ All outputs generated successfully"
 
       - name: Upload report as artifact
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v4
         with:
           name: daily-report-${{ github.run_number }}
           path: |
@@ -64,11 +64,10 @@ jobs:
           retention-days: 30
 
       - name: Send email with report
-        uses: dawidd6/action-send-mail@v3.12.0
+        uses: dawidd6/action-send-mail@v3
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
Fixes warnings in the Daily Empire Report GitHub action by removing an unsupported `starttls: true` parameter and updates action dependencies to their major version tags.

Note: The workflow is currently failing due to an "Invalid login: 535-5.7.8 Username and Password not accepted" error from Google SMTP. This is due to the `EMAIL_PASS` secret. I have alerted the user to update the repository secret to use a valid App Password.

---
*PR created automatically by Jules for task [16999903856830315109](https://jules.google.com/task/16999903856830315109) started by @mrdannyclark82*

## Summary by Sourcery

Update the Daily Empire workflow to use the latest major versions of third-party actions and remove an unsupported email configuration option to clear CI warnings.

Build:
- Bump actions/upload-artifact to the v4 major tag in the daily-empire GitHub Actions workflow.
- Bump dawidd6/action-send-mail to the v3 major tag and drop the unsupported starttls parameter from the email step in the daily-empire workflow.