### PR TITLE
Fix daily-empire workflow warning and flaky test

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -68,7 +68,6 @@ jobs:
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'

--- a/server/__tests__/geminiToolService.test.ts
+++ b/server/__tests__/geminiToolService.test.ts
@@ -92,7 +92,7 @@ describe('Gemini Tool Service - Parallel Execution', () => {
 
       const results = await executeToolCallsInParallel(toolCalls);
 
-      expect(results[0].executionTime).toBeGreaterThanOrEqual(10);
+      expect(results[0].executionTime).toBeGreaterThanOrEqual(9);
     });
 
     it('should execute single tool call', async () => {


### PR DESCRIPTION
Fixes an issue with the "Daily Empire Report" GitHub Action workflow failing with an "Unexpected input" warning related to `starttls`. Also addresses a flaky test in the `geminiToolService.test.ts` test suite.

Note: The primary workflow failure (Google SMTP "Username and Password not accepted") requires the user to manually update the `EMAIL_PASS` GitHub repository secret with a valid Google App Password, as explicitly communicated via message.

---
*PR created automatically by Jules for task [17662959260970823392](https://jules.google.com/task/17662959260970823392) started by @mrdannyclark82*

## Summary by Sourcery

Relax flaky parallel execution test timing and update the daily empire email workflow configuration to remove an unsupported input.

Bug Fixes:
- Stabilize the parallel execution timing assertion in geminiToolService tests to reduce flakiness.

CI:
- Update the Daily Empire Report GitHub Action to stop passing the deprecated or unsupported starttls input to the email step.