### PR TITLE
fix: remove invalid starttls parameter from email action in daily-empire.yml

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -68,7 +68,6 @@ jobs:
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
This commit removes the invalid `starttls: true` parameter from the `dawidd6/action-send-mail` GitHub Action step in `.github/workflows/daily-empire.yml`. Since this parameter is not supported, passing it was causing an unexpected input issue. The workflow connects to port 587 which uses STARTTLS automatically.

Additionally, this investigation found that the underlying error could also be caused by Google requiring an App Password for SMTP authentication, so the user was notified to verify their `EMAIL_PASS` secret.

---
*PR created automatically by Jules for task [11834083058815563804](https://jules.google.com/task/11834083058815563804) started by @mrdannyclark82*

## Summary by Sourcery

Bug Fixes:
- Fix daily email workflow failures by dropping the invalid starttls parameter from the send-mail action configuration.