### PR TITLE
Fix action-send-mail parameters

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -68,7 +68,6 @@ jobs:
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
Removed the unsupported `starttls: true` parameter from the `dawidd6/action-send-mail` step in the `Daily Empire Report` workflow, as it was causing workflow validation errors. Standard Node-based SMTP mailers automatically upgrade to STARTTLS on port 587, making this flag unnecessary.

---
*PR created automatically by Jules for task [13279211900685248396](https://jules.google.com/task/13279211900685248396) started by @mrdannyclark82*

## Summary by Sourcery

CI:
- Update Daily Empire Report GitHub Actions workflow to rely on default STARTTLS behavior by removing the unsupported starttls parameter.