### PR TITLE
Fix Daily Empire workflow action configurations

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -55,7 +55,7 @@ jobs:
           echo "✓ All outputs generated successfully"
 
       - name: Upload report as artifact
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v4
         with:
           name: daily-report-${{ github.run_number }}
           path: |
@@ -64,11 +64,10 @@ jobs:
           retention-days: 30
 
       - name: Send email with report
-        uses: dawidd6/action-send-mail@v3.12.0
+        uses: dawidd6/action-send-mail@v3
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
Analyzed the Daily Empire GitHub Actions workflow failure. Found that the `dawidd6/action-send-mail` action was failing due to an invalid `starttls` parameter. Removed this parameter and updated the action tags to their major versions to align with best practices and prevent future deprecation failures. Also advised the user via a message to verify their Google SMTP App Password, which may be the root cause of the initial authentication failure triggering the workflow error. Checked all tests and they pass.

---
*PR created automatically by Jules for task [1613569053954615594](https://jules.google.com/task/1613569053954615594) started by @mrdannyclark82*

## Summary by Sourcery

Update the Daily Empire GitHub Actions workflow to use major-version tags for third-party actions and remove an invalid mail action configuration causing workflow failures.

CI:
- Bump actions/upload-artifact to the v4 major tag in the Daily Empire workflow.
- Bump dawidd6/action-send-mail to the v3 major tag and drop the unsupported starttls parameter in the Daily Empire workflow.