### PR TITLE
Fix Daily Empire Report workflow failure

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -55,7 +55,7 @@ jobs:
           echo "✓ All outputs generated successfully"
 
       - name: Upload report as artifact
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v4
         with:
           name: daily-report-${{ github.run_number }}
           path: |
@@ -64,11 +64,10 @@ jobs:
           retention-days: 30
 
       - name: Send email with report
-        uses: dawidd6/action-send-mail@v3.12.0
+        uses: dawidd6/action-send-mail@v3
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
The `Daily Empire Report` workflow failed at the `Send email with report` step. Upon investigating, it was found that the `dawidd6/action-send-mail` was failing because the `starttls` parameter is no longer supported and throws unexpected input errors. 

This commit:
- Removes `starttls: true` from the `dawidd6/action-send-mail` step.
- Updates `actions/upload-artifact@v4.0.0` to `actions/upload-artifact@v4`.
- Updates `dawidd6/action-send-mail@v3.12.0` to `dawidd6/action-send-mail@v3` to comply with the project's rules to use major version tags for these GitHub actions.

Tests run locally passed.

---
*PR created automatically by Jules for task [3901636436069621998](https://jules.google.com/task/3901636436069621998) started by @mrdannyclark82*

## Summary by Sourcery

Fix the Daily Empire Report GitHub Actions workflow email step and align action versions with major-version tags.

Bug Fixes:
- Resolve workflow failure in the Daily Empire Report email-sending step by removing an unsupported parameter from the mail action.

Enhancements:
- Update GitHub Actions dependencies to use stable major-version tags for artifact upload and email sending.