### PR TITLE
ci: fix warnings in daily-empire workflow

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -55,7 +55,7 @@ jobs:
           echo "✓ All outputs generated successfully"
 
       - name: Upload report as artifact
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v4
         with:
           name: daily-report-${{ github.run_number }}
           path: |
@@ -64,11 +64,10 @@ jobs:
           retention-days: 30
 
       - name: Send email with report
-        uses: dawidd6/action-send-mail@v3.12.0
+        uses: dawidd6/action-send-mail@v3
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
This commit addresses the warnings in the `.github/workflows/daily-empire.yml` GitHub Actions workflow:

1. **Unexpected Input Warning**: Removed the `starttls: true` parameter from `dawidd6/action-send-mail`, as the action does not support this input natively (it defaults to STARTTLS on port 587 anyway), which caused a workflow warning.
2. **Action Deprecation Warnings**: Updated hardcoded action versions to their major version tags (`actions/upload-artifact@v4` and `dawidd6/action-send-mail@v3`) to align with GitHub's best practices and avoid Node 20 deprecation warnings on older versions.

Note: The underlying workflow failure was an authentication error (`535-5.7.8 Username and Password not accepted`) due to an invalid `EMAIL_PASS` secret. The user has been advised to update the repository secret to a valid Google App Password.

---
*PR created automatically by Jules for task [17233678388621843400](https://jules.google.com/task/17233678388621843400) started by @mrdannyclark82*

## Summary by Sourcery

Update the daily-empire GitHub Actions workflow to clear deprecation and input warnings in the email/report steps.

CI:
- Relax action version pins in daily-empire workflow to major tags for upload-artifact and action-send-mail.
- Remove unsupported STARTTLS input from the email step in daily-empire workflow to eliminate GitHub Actions warnings.