### PR TITLE
ci: fix daily empire email action starttls failure

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -68,7 +68,6 @@ jobs:
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
Fixes the `Daily Empire Report` workflow failing at the `Send email with report` step.

**Issue**: The `dawidd6/action-send-mail` GitHub Action was failing because it received an unexpected input parameter `starttls: true` which is not supported by the action schema.

**Fix**:
- Removed the `starttls: true` line from `.github/workflows/daily-empire.yml`.
- Validated tests run properly to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [6980546503197618402](https://jules.google.com/task/6980546503197618402) started by @mrdannyclark82*

## Summary by Sourcery

CI:
- Remove unsupported starttls parameter from the Daily Empire Report GitHub Actions workflow to prevent email-sending failures.