### PR TITLE
Fix Daily Empire workflow failing at email step

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -55,7 +55,7 @@ jobs:
           echo "✓ All outputs generated successfully"
 
       - name: Upload report as artifact
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v4
         with:
           name: daily-report-${{ github.run_number }}
           path: |
@@ -64,11 +64,10 @@ jobs:
           retention-days: 30
 
       - name: Send email with report
-        uses: dawidd6/action-send-mail@v3.12.0
+        uses: dawidd6/action-send-mail@v3
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
This commit fixes the failing "Daily Empire Report" GitHub Actions workflow. The failure was caused by passing an invalid `starttls: true` parameter to the `dawidd6/action-send-mail` action.

Changes made:
- Removed `starttls: true` from the email step.
- Updated `actions/upload-artifact` from `@v4.0.0` to `@v4` to align with standard practices.
- Updated `dawidd6/action-send-mail` from `@v3.12.0` to `@v3` to align with standard practices.

---
*PR created automatically by Jules for task [13619928447665218428](https://jules.google.com/task/13619928447665218428) started by @mrdannyclark82*

## Summary by Sourcery

Fix the Daily Empire GitHub Actions workflow email step to restore successful runs by adjusting mail action configuration and dependency versions.

Build:
- Update actions/upload-artifact to the floating v4 tag in the Daily Empire workflow.
- Update dawidd6/action-send-mail to the floating v3 tag in the Daily Empire workflow.

CI:
- Remove the unsupported starttls parameter from the email step in the Daily Empire workflow to prevent failures.