### PR TITLE
Fix Daily Empire workflow warnings and update versions

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -55,7 +55,7 @@ jobs:
           echo "✓ All outputs generated successfully"
 
       - name: Upload report as artifact
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v4
         with:
           name: daily-report-${{ github.run_number }}
           path: |
@@ -64,11 +64,10 @@ jobs:
           retention-days: 30
 
       - name: Send email with report
-        uses: dawidd6/action-send-mail@v3.12.0
+        uses: dawidd6/action-send-mail@v3
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
Fixed the unexpected input warnings in the `Daily Empire Report` workflow and updated GitHub Action dependencies to major version tags. Notified user about the external SMTP credential failure.

---
*PR created automatically by Jules for task [14594457210732722115](https://jules.google.com/task/14594457210732722115) started by @mrdannyclark82*

## Summary by Sourcery

Update the Daily Empire Report workflow to use major-version GitHub Actions and remove deprecated SMTP input to eliminate warnings.

Enhancements:
- Relax GitHub Action version pins in the Daily Empire workflow to major tags for upload-artifact and send-mail.

CI:
- Adjust Daily Empire workflow email step configuration to remove the unsupported starttls input and rely on default TLS behavior.