### PR TITLE
ci: Fix daily-empire workflow email and artifact configuration

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -55,7 +55,7 @@ jobs:
           echo "✓ All outputs generated successfully"
 
       - name: Upload report as artifact
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v4
         with:
           name: daily-report-${{ github.run_number }}
           path: |
@@ -68,7 +68,6 @@ jobs:
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
Fixes errors and warnings in the `.github/workflows/daily-empire.yml` file.

- Removed the unsupported `starttls` parameter from the `dawidd6/action-send-mail` step, which was causing an `Unexpected input(s) 'starttls'` warning and potential strict-mode failure.
- Updated `actions/upload-artifact` from `v4.0.0` to major version `v4` to align with best practices and pick up non-breaking updates automatically.
- Analyzed the `Invalid login` error and confirmed it stems from the repository secret `EMAIL_PASS`, notifying the user to update it to a valid Google App Password.

---
*PR created automatically by Jules for task [750685011873136918](https://jules.google.com/task/750685011873136918) started by @mrdannyclark82*

## Summary by Sourcery

Update daily-empire CI workflow email and artifact configuration to align with supported inputs and current action versions.

CI:
- Bump actions/upload-artifact in the daily-empire workflow to use the v4 major tag.
- Remove the unsupported starttls input from the daily-empire email notification step configuration.