### PR TITLE
ci: fix daily-empire workflow deprecations and warnings

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -55,7 +55,7 @@ jobs:
           echo "✓ All outputs generated successfully"
 
       - name: Upload report as artifact
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v4
         with:
           name: daily-report-${{ github.run_number }}
           path: |
@@ -64,11 +64,10 @@ jobs:
           retention-days: 30
 
       - name: Send email with report
-        uses: dawidd6/action-send-mail@v3.12.0
+        uses: dawidd6/action-send-mail@v3
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
Fixes the "Daily Empire Report" workflow which was failing.

Changes:
1. Updated `actions/upload-artifact@v4.0.0` to `v4` to address Node.js 20 deprecation warnings.
2. Updated `dawidd6/action-send-mail@v3.12.0` to `v3` to address Node.js 20 deprecation warnings.
3. Removed the invalid `starttls: true` parameter from the `dawidd6/action-send-mail` configuration to resolve an "Unexpected input" warning.

Note: The final failure in the job was a `535-5.7.8 Username and Password not accepted` error during the email step. The user has been advised to update the `EMAIL_PASS` repository secret to use a valid Google App Password, as standard passwords are no longer supported for SMTP authentication.

---
*PR created automatically by Jules for task [8130836396397457574](https://jules.google.com/task/8130836396397457574) started by @mrdannyclark82*

## Summary by Sourcery

Update the Daily Empire report GitHub Actions workflow to address deprecations and clean up configuration.

CI:
- Bump upload-artifact to v4 and action-send-mail to v3 in the daily-empire workflow to resolve Node.js 20 deprecation warnings.
- Remove the unsupported starttls parameter from the send-mail step in the daily-empire workflow to eliminate configuration warnings.