### PR TITLE
Fix invalid starttls parameter in daily-empire workflow

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -68,7 +68,6 @@ jobs:
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
Removes the invalid `starttls` parameter from the `daily-empire.yml` GitHub workflow to resolve an 'Unexpected input' warning. The user has been notified separately regarding the SMTP credential failure. Tests ran successfully.

---
*PR created automatically by Jules for task [14509955910863491899](https://jules.google.com/task/14509955910863491899) started by @mrdannyclark82*

## Summary by Sourcery

CI:
- Remove the invalid starttls input from the daily-empire GitHub Actions workflow email step to resolve the unexpected input warning.