### PR TITLE
Fix: Resolve GitHub workflow warnings for the daily empire report

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -55,7 +55,7 @@ jobs:
           echo "✓ All outputs generated successfully"
 
       - name: Upload report as artifact
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v4
         with:
           name: daily-report-${{ github.run_number }}
           path: |
@@ -68,7 +68,6 @@ jobs:
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
Resolved two warnings produced by the daily-empire report GitHub Actions workflow, by updating the artifact upload version tracking to minor version and removing a deprecated parameter that threw an unexpected inputs warning. Advised the user to resolve the core failure manually since the workflow failure was explicitly due to Invalid SMTP credentials due to not using an App Password for Gmail.

---
*PR created automatically by Jules for task [10438657863929517660](https://jules.google.com/task/10438657863929517660) started by @mrdannyclark82*

## Summary by Sourcery

Resolve warnings in the daily-empire GitHub Actions workflow by updating the artifact upload action reference and removing a deprecated email action parameter.

CI:
- Update the daily-empire workflow to use the minor-version tag for actions/upload-artifact.
- Remove the deprecated starttls input from the email action configuration in the daily-empire workflow.