### PR TITLE
ci: Fix Daily Empire Report Workflow failures

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -55,7 +55,7 @@ jobs:
           echo "✓ All outputs generated successfully"
 
       - name: Upload report as artifact
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v4
         with:
           name: daily-report-${{ github.run_number }}
           path: |
@@ -64,11 +64,10 @@ jobs:
           retention-days: 30
 
       - name: Send email with report
-        uses: dawidd6/action-send-mail@v3.12.0
+        uses: dawidd6/action-send-mail@v3
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
This change fixes the `daily-analysis` job failure in the Daily Empire Report workflow. 
The job failed on the "Send email with report" step because `dawidd6/action-send-mail` was failing strict mode validation due to an unrecognized `starttls` parameter. The workflow was also using hardcoded specific patch versions instead of major tags.

Changes made:
- Replaced `actions/upload-artifact@v4.0.0` with `@v4`
- Replaced `dawidd6/action-send-mail@v3.12.0` with `@v3`
- Removed `starttls: true` from the send-mail configuration (it implicitly uses STARTTLS on port 587).

---
*PR created automatically by Jules for task [11475648950360341313](https://jules.google.com/task/11475648950360341313) started by @mrdannyclark82*

## Summary by Sourcery

Update the Daily Empire Report GitHub Actions workflow to use major-version tags for actions and fix email sending failures.

CI:
- Relax action version pinning in the Daily Empire Report workflow to track the latest v4 upload-artifact and v3 send-mail releases.
- Adjust the email step configuration by removing the unsupported STARTTLS parameter so the daily-analysis job succeeds.