### PR TITLE
Fix CI failures by migrating pnpm references to npm

### DIFF
--- a/.github/actions/setup-monorepo/action.yml
+++ b/.github/actions/setup-monorepo/action.yml
@@ -1,5 +1,5 @@
 name: 'Setup Milla Empire Monorepo'
-description: 'Fast pnpm + Node + Turbo + Gradle cache setup'
+description: 'Fast npm + Node + Turbo + Gradle cache setup'
 inputs:
   node-version:
     description: 'Node version'
@@ -8,22 +8,10 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: pnpm/action-setup@v4
-      with:
-        version: 9
     - uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
-        cache: 'pnpm'
-    - name: Get pnpm store directory
-      shell: bash
-      run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_ENV
-    - uses: actions/cache@v4
-      with:
-        path: ${{ env.STORE_PATH }}
-        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-        restore-keys: |
-          ${{ runner.os }}-pnpm-store-
+        cache: 'npm'
     - name: Cache Turborepo
       uses: actions/cache@v4
       with:
@@ -33,4 +21,4 @@ runs:
           turbo-${{ runner.os }}-
     - name: Install dependencies
       shell: bash
-      run: pnpm install --frozen-lockfile
+      run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-monorepo
-      - run: pnpm lint
-      - run: pnpm test
+      - run: npm run lint
+      - run: npm run test
 
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-monorepo
-      - run: pnpm build
+      - run: npm run build


### PR DESCRIPTION
The `ci.yml` workflow was failing during execution of the `setup-monorepo` composite action and subsequently running `pnpm lint`, `pnpm test`, and `pnpm build`. 
The failure stems from the project being configured for `npm` (evident by `package-lock.json`), but GitHub Actions scripts were trying to use `pnpm` commands and setup actions which were not correctly installed or configured.

Changes:
- Replaced `pnpm/action-setup` cache mechanisms in `.github/actions/setup-monorepo/action.yml` with native `actions/setup-node` `cache: 'npm'`.
- Changed `pnpm install --frozen-lockfile` to `npm ci` in `setup-monorepo`.
- Modified `.github/workflows/ci.yml` commands from `pnpm <script>` to `npm run <script>`.

---
*PR created automatically by Jules for task [797697549908009260](https://jules.google.com/task/797697549908009260) started by @mrdannyclark82*

## Summary by Sourcery

Align CI workflows and monorepo setup with npm instead of pnpm to resolve pipeline failures.

Build:
- Switch the monorepo setup action to use npm dependency installation and caching instead of pnpm.

CI:
- Update CI workflows to run lint, test, and build scripts via npm rather than pnpm.