### PR TITLE
Fix Daily Empire Workflow Email Step

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -55,7 +55,7 @@ jobs:
           echo "✓ All outputs generated successfully"
 
       - name: Upload report as artifact
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v4
         with:
           name: daily-report-${{ github.run_number }}
           path: |
@@ -68,7 +68,6 @@ jobs:
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
The `Daily Empire Report` workflow was failing on the `Send email with report` step because the `dawidd6/action-send-mail` action does not support a `starttls` parameter (it utilizes `secure` or handles STARTTLS automatically on port 587). This commit removes the invalid parameter to resolve strict-mode warnings/failures. Additionally, `actions/upload-artifact` has been updated to the major `v4` tag instead of the hardcoded patch version `v4.0.0` to adhere to standard GitHub Actions best practices.

---
*PR created automatically by Jules for task [2929594355016743170](https://jules.google.com/task/2929594355016743170) started by @mrdannyclark82*

## Summary by Sourcery

Update the Daily Empire workflow configuration to fix the email-sending step and align action versions with GitHub Actions best practices.

Enhancements:
- Relax the actions/upload-artifact dependency to the major v4 tag instead of a specific patch version.

CI:
- Remove the unsupported starttls parameter from the dawidd6/action-send-mail step in the Daily Empire workflow to resolve workflow failures.