### PR TITLE
ci: fix daily empire workflow email step parameters

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -55,7 +55,7 @@ jobs:
           echo "✓ All outputs generated successfully"
 
       - name: Upload report as artifact
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v4
         with:
           name: daily-report-${{ github.run_number }}
           path: |
@@ -68,7 +68,6 @@ jobs:
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
This commit fixes a failing GitHub Actions workflow for the "Daily Empire Report". 

The `dawidd6/action-send-mail` step was failing because `starttls` is not a valid input parameter for the action. I removed it, allowing the default behavior (which automatically uses STARTTLS on port 587) to take effect. I additionally took the opportunity to bump `actions/upload-artifact` from a hardcoded patch version (`v4.0.0`) to a major version pointer (`v4`) according to standard GitHub Actions best practices. All codebase tests have been run and verified.

---
*PR created automatically by Jules for task [3716957646123853191](https://jules.google.com/task/3716957646123853191) started by @mrdannyclark82*

## Summary by Sourcery

Fix the Daily Empire GitHub Actions workflow email step and align artifact upload action with recommended versioning.

Build:
- Update the daily-empire workflow to use actions/upload-artifact@v4 instead of a pinned patch version.
- Remove the unsupported starttls parameter from the dawidd6/action-send-mail step to restore the Daily Empire report email sending.