### PR TITLE
ci: fix Daily Empire Report workflow starttls failure

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -55,7 +55,7 @@ jobs:
           echo "✓ All outputs generated successfully"
 
       - name: Upload report as artifact
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v4
         with:
           name: daily-report-${{ github.run_number }}
           path: |
@@ -68,7 +68,6 @@ jobs:
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
The Daily Empire Report workflow was failing during the "Send email with report" step because `dawidd6/action-send-mail` was being passed `starttls: true`. This parameter is not an officially supported input for that action (it uses parameters like `secure` or `ignore_cert` instead), and passing it causes a strict-mode failure due to unexpected inputs. Removing it resolves the issue, and since the workflow uses port 587, the underlying mail client will automatically use STARTTLS anyway. I've also updated `actions/upload-artifact` to use the major version tag `v4`.

I've also advised the user to double check that they are using a valid Google App Password for their `EMAIL_PASS` secret since Google requires this for SMTP authentication.

---
*PR created automatically by Jules for task [2309774571217962247](https://jules.google.com/task/2309774571217962247) started by @mrdannyclark82*

## Summary by Sourcery

Fix the Daily Empire Report email workflow by removing an unsupported mail action input and updating artifact upload to the latest major version.

CI:
- Remove unsupported starttls input from the send-mail step in the Daily Empire Report workflow to prevent strict-mode failures.
- Update actions/upload-artifact usage in the Daily Empire Report workflow to reference the v4 major version tag instead of a specific patch version.