### PR TITLE
Fix Daily Empire Report workflow failure

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -55,7 +55,7 @@ jobs:
           echo "✓ All outputs generated successfully"
 
       - name: Upload report as artifact
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v4
         with:
           name: daily-report-${{ github.run_number }}
           path: |
@@ -64,11 +64,10 @@ jobs:
           retention-days: 30
 
       - name: Send email with report
-        uses: dawidd6/action-send-mail@v3.12.0
+        uses: dawidd6/action-send-mail@v3
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
This PR fixes the failing "Daily Empire Report" workflow. The `dawidd6/action-send-mail` action was failing because it was provided with an invalid `starttls: true` parameter. This parameter has been removed (port 587 automatically uses STARTTLS). Additionally, action versions have been updated to use major tags (`@v4`, `@v3`) instead of hardcoded patch versions to ensure ongoing compatibility.

---
*PR created automatically by Jules for task [5349682800079325269](https://jules.google.com/task/5349682800079325269) started by @mrdannyclark82*

## Summary by Sourcery

Update the Daily Empire Report GitHub Actions workflow to fix the email step failure and align action dependencies with major version tags.

Build:
- Switch upload-artifact action to use the v4 major tag instead of a pinned patch version.
- Switch dawidd6/action-send-mail to the v3 major tag and remove the invalid starttls configuration to restore email sending in the workflow.