### PR TITLE
Fix daily empire report email configuration

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -55,7 +55,7 @@ jobs:
           echo "✓ All outputs generated successfully"
 
       - name: Upload report as artifact
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v4
         with:
           name: daily-report-${{ github.run_number }}
           path: |
@@ -64,11 +64,10 @@ jobs:
           retention-days: 30
 
       - name: Send email with report
-        uses: dawidd6/action-send-mail@v3.12.0
+        uses: dawidd6/action-send-mail@v3
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
Fixes a failure in the Daily Empire Report GitHub Actions workflow due to an unrecognized parameter on the email sending step. Additionally proactively advises the user to configure Gmail App Passwords since SMTP requires them instead of standard account passwords.

---
*PR created automatically by Jules for task [10836817379845726428](https://jules.google.com/task/10836817379845726428) started by @mrdannyclark82*

## Summary by Sourcery

Update the Daily Empire report workflow email and artifact steps to use supported action versions and configuration.

Build:
- Bump actions/upload-artifact from v4.0.0 to v4 in the daily-empire GitHub Actions workflow.
- Update dawidd6/action-send-mail from v3.12.0 to v3 and remove the unsupported starttls parameter in the workflow configuration.