### PR TITLE
Fix Daily Empire Report Workflow Failure

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -68,7 +68,6 @@ jobs:
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
The `Daily Empire Report` workflow was failing on the `Send email with report` step. Upon investigation, the failure was caused by the inclusion of the `starttls: true` parameter in the `dawidd6/action-send-mail` configuration. This action does not accept a `starttls` input parameter, resulting in a strict-mode failure. I removed the parameter to resolve the issue.

Steps taken:
1. Identified the failing workflow and step via the GitHub Actions API.
2. Verified the `.github/workflows/daily-empire.yml` file and removed the invalid `starttls: true` parameter using `sed`.
3. Ran local tests (`npm run test`) to ensure repository stability.
4. Cleaned up untracked artifacts generated by the test run to keep the working tree clean.
5. Successfully completed the code review process.

---
*PR created automatically by Jules for task [2857441054086415664](https://jules.google.com/task/2857441054086415664) started by @mrdannyclark82*

## Summary by Sourcery

CI:
- Remove unsupported starttls parameter from the Daily Empire Report workflow email step to prevent action failure.