### PR TITLE
Fix GitHub Action Workflow Failures

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,13 +7,6 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: 'deps(npm)'
-  - package-ecosystem: 'pip'
-    directory: '/'
-    schedule:
-      interval: 'weekly'
-    open-pull-requests-limit: 3
-    commit-message:
-      prefix: 'deps(pip)'
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:

--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -55,7 +55,7 @@ jobs:
           echo "✓ All outputs generated successfully"
 
       - name: Upload report as artifact
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v4
         with:
           name: daily-report-${{ github.run_number }}
           path: |
@@ -64,11 +64,10 @@ jobs:
           retention-days: 30
 
       - name: Send email with report
-        uses: dawidd6/action-send-mail@v3.12.0
+        uses: dawidd6/action-send-mail@v3
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
Fixes for failing GitHub actions/workflows:
- Dependabot config updated to remove pip ecosystem.
- `daily-empire.yml` email step updated to remove `starttls` which causes failures.
- Updated action versions in `daily-empire.yml`.

---
*PR created automatically by Jules for task [9516784866860045383](https://jules.google.com/task/9516784866860045383) started by @mrdannyclark82*

## Summary by Sourcery

Resolve GitHub workflow failures by simplifying dependency update configuration and updating the daily report workflow email and artifact steps.

Build:
- Remove pip ecosystem configuration from Dependabot to stop managing Python dependencies via automated PRs.
- Update GitHub Actions workflow versions and email step configuration in the daily-empire workflow to align with supported settings.