### PR TITLE
Fix action-send-mail unexpected input starttls

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -68,7 +68,6 @@ jobs:
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
The Daily Empire Report workflow was failing because the `dawidd6/action-send-mail` step had `starttls: true` configured, which is not a valid input parameter for this action and causes an unexpected input error.

This commit removes the `starttls: true` configuration, allowing the action to rely on its default automatic STARTTLS negotiation for port 587, and resolving the workflow failure.

---
*PR created automatically by Jules for task [17147528262418314224](https://jules.google.com/task/17147528262418314224) started by @mrdannyclark82*

## Summary by Sourcery

Fix the Daily Empire Report GitHub Actions workflow configuration to prevent mail-sending failures due to an invalid action input.

Bug Fixes:
- Remove the unsupported starttls parameter from the dawidd6/action-send-mail step to resolve the unexpected input error in the workflow.

CI:
- Adjust the daily-empire workflow mail step configuration to rely on the action's default STARTTLS handling for port 587.