### PR TITLE
Fix Daily Empire workflow parameter and action version

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -55,7 +55,7 @@ jobs:
           echo "✓ All outputs generated successfully"
 
       - name: Upload report as artifact
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v4
         with:
           name: daily-report-${{ github.run_number }}
           path: |
@@ -68,7 +68,6 @@ jobs:
         with:
           server_address: smtp.gmail.com
           server_port: 587
-          starttls: true
           username: ${{ secrets.EMAIL_FROM }}
           password: ${{ secrets.EMAIL_PASS }}
           subject: '🚀 Daily Empire Report - ${{ github.run_number }}'


### PR DESCRIPTION
Fix daily empire workflow errors

- Removed unsupported `starttls: true` parameter from `dawidd6/action-send-mail` action.
- Upgraded `actions/upload-artifact` from v4.0.0 to v4 to prevent deprecation issues and receive non-breaking updates.

---
*PR created automatically by Jules for task [4989952959882554878](https://jules.google.com/task/4989952959882554878) started by @mrdannyclark82*

## Summary by Sourcery

Update the Daily Empire GitHub Actions workflow to use supported configuration and non-deprecated action versions.

CI:
- Bump actions/upload-artifact from v4.0.0 to the v4 major tag in the daily-empire workflow.
- Remove the unsupported starttls parameter from the dawidd6/action-send-mail step in the daily-empire workflow.