### PR TITLE
Fix branch dashboard snapshot workflow

### DIFF
--- a/.github/workflows/branch-dashboard.yml
+++ b/.github/workflows/branch-dashboard.yml
@@ -43,6 +43,10 @@ jobs:
                 owner, repo, basehead: `main...${b.name}`
               });
 
+              const commitData = await github.rest.repos.getCommit({
+                owner, repo, ref: b.commit.sha
+              });
+
               rows.push({
                 branch: b.name,
                 linked_pr: prByHead.get(b.name) || null,
@@ -51,7 +55,7 @@ jobs:
                 behind_by: cmp.data.behind_by,
                 duplicate_sha: bySha.get(b.commit.sha).length > 1,
                 commit_sha: b.commit.sha,
-                last_commit_date: b.commit.commit.author.date
+                last_commit_date: commitData.data.commit.author.date
               });
             }
 


### PR DESCRIPTION
Fixes a failing GitHub action workflow (`Branch Dashboard Snapshot`) which was throwing a TypeError `Cannot read properties of undefined (reading 'author')` because it tried to access the commit date from the `listBranches` response (which only includes `sha` and `url`). The fix correctly fetches the detailed commit via `getCommit` inside the loop. 

Also identified the root cause of the "Daily Empire Report" failure (the Gmail SMTP account needs an App Password instead of a standard password for `EMAIL_PASS`), and messaged the user to resolve the credential issue externally.

---
*PR created automatically by Jules for task [10118581305757598894](https://jules.google.com/task/10118581305757598894) started by @mrdannyclark82*

## Summary by Sourcery

Bug Fixes:
- Resolve a TypeError in the Branch Dashboard Snapshot workflow by retrieving commit metadata via a dedicated commit lookup instead of relying on the branch listing response.