### PR TITLE
Fix branch dashboard workflow crash

### DIFF
--- a/.github/workflows/branch-dashboard.yml
+++ b/.github/workflows/branch-dashboard.yml
@@ -43,6 +43,10 @@ jobs:
                 owner, repo, basehead: `main...${b.name}`
               });
 
+              const commitDetails = await github.rest.repos.getCommit({
+                owner, repo, ref: b.commit.sha
+              });
+
               rows.push({
                 branch: b.name,
                 linked_pr: prByHead.get(b.name) || null,
@@ -51,7 +55,7 @@ jobs:
                 behind_by: cmp.data.behind_by,
                 duplicate_sha: bySha.get(b.commit.sha).length > 1,
                 commit_sha: b.commit.sha,
-                last_commit_date: b.commit.commit.author.date
+                last_commit_date: commitDetails.data.commit.author.date
               });
             }
 


### PR DESCRIPTION
This fixes the TypeError in `.github/workflows/branch-dashboard.yml` where `author.date` was being accessed on `listBranches` API output that did not include it. It makes an explicit call to get commit details. Also addressed a failing `Daily Empire Report` workflow via message to user regarding `EMAIL_PASS`.

---
*PR created automatically by Jules for task [9967816190520308252](https://jules.google.com/task/9967816190520308252) started by @mrdannyclark82*

## Summary by Sourcery

Bug Fixes:
- Fix branch dashboard workflow crash caused by reading author date from incomplete branch list API responses.