### PR TITLE
fix(github-actions): migrate setup-node to v22 and notify user of auth failure

### DIFF
--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -20,10 +20,10 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Setup Node.js 20
+      - name: Setup Node.js 22
         uses: actions/setup-node@v4
         with:
-          node-version: '20.10.0'
+          node-version: '22.x'
           cache: 'npm'
 
       - name: Install analysis dependencies


### PR DESCRIPTION
This PR fixes a deprecation warning in `.github/workflows/daily-empire.yml` by updating the `actions/setup-node@v4` configuration to target Node.js 22 instead of Node.js 20. It was also determined that the core failure in the workflow is due to an invalid SMTP credential (`EMAIL_PASS`); the user has been notified to generate and configure a valid Google App Password.

---
*PR created automatically by Jules for task [13378846462321615286](https://jules.google.com/task/13378846462321615286) started by @mrdannyclark82*

## Summary by Sourcery

CI:
- Update the daily-empire workflow to target Node.js 22.x instead of 20.10.0 in the setup-node configuration.