### PR TITLE
Fix failing GitHub workflows and update Node.js target

### DIFF
--- a/.github/workflows/branch-dashboard.yml
+++ b/.github/workflows/branch-dashboard.yml
@@ -43,6 +43,10 @@ jobs:
                 owner, repo, basehead: `main...${b.name}`
               });
 
+              const commitDetails = await github.rest.repos.getCommit({
+                owner, repo, ref: b.commit.sha
+              });
+
               rows.push({
                 branch: b.name,
                 linked_pr: prByHead.get(b.name) || null,
@@ -51,7 +55,7 @@ jobs:
                 behind_by: cmp.data.behind_by,
                 duplicate_sha: bySha.get(b.commit.sha).length > 1,
                 commit_sha: b.commit.sha,
-                last_commit_date: b.commit.commit.author.date
+                last_commit_date: commitDetails.data.commit.author.date
               });
             }
 

--- a/.github/workflows/copilot-agent-fix.yml
+++ b/.github/workflows/copilot-agent-fix.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: '22.x'
           cache: 'npm'
       - name: Show runtime & dependency info
         run: |

--- a/.github/workflows/daily-empire.yml
+++ b/.github/workflows/daily-empire.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js 20
         uses: actions/setup-node@v4
         with:
-          node-version: '20.10.0'
+          node-version: '22.x'
           cache: 'npm'
 
       - name: Install analysis dependencies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           cache: npm
 
       - name: Install dependencies
@@ -80,7 +80,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           cache: npm
 
       - name: Install dependencies
@@ -163,7 +163,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '22.x'
 
       - name: Build application
         run: |
@@ -220,7 +220,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -69,6 +69,11 @@ jobs:
       additional_context: '${{ steps.extract_command.outputs.additional_context }}'
       issue_number: '${{ github.event.pull_request.number || github.event.issue.number }}'
     steps:
+      - name: 'Checkout repository'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
       - name: 'Mint identity token'
         id: 'mint_identity_token'
         uses: ./.github/actions/mint-token
@@ -171,6 +176,11 @@ jobs:
       issues: 'write'
       pull-requests: 'write'
     steps:
+      - name: 'Checkout repository'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
       - name: 'Mint identity token'
         id: 'mint_identity_token'
         uses: ./.github/actions/mint-token

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           cache: npm
 
       - name: Install dependencies
@@ -48,7 +48,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           cache: npm
 
       - name: Install dependencies
@@ -70,7 +70,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           cache: npm
 
       - name: Install dependencies
@@ -104,7 +104,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           cache: npm
 
       - name: Install dependencies
@@ -133,7 +133,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           cache: npm
 
       - name: Install dependencies
@@ -162,7 +162,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           cache: npm
 
       - name: Run npm audit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           cache: npm
 
       - name: Install dependencies


### PR DESCRIPTION
Fix failing GitHub workflows and update Node.js target

- branch-dashboard.yml: Fix missing commit metadata fetch
- gemini-dispatch.yml: Add missing checkout step before local action
- *.yml: Bump setup-node target from 20 to 22.x to clear deprecations

---
*PR created automatically by Jules for task [1387927821652092938](https://jules.google.com/task/1387927821652092938) started by @mrdannyclark82*

## Summary by Sourcery

Update GitHub workflows to use Node.js 22 and fix issues with branch metadata retrieval and Gemini dispatch actions.

Bug Fixes:
- Ensure branch dashboard workflow retrieves full commit metadata before using author dates.
- Fix Gemini dispatch workflow failures by checking out the repository before running local actions.

Enhancements:
- Standardize all Node.js GitHub Actions workflows on Node.js 22.x to address deprecations and keep CI up to date.

CI:
- Update CI workflows to target Node.js 22.x across PR checks, deployment, daily jobs, Copilot fix, and release pipelines.