### PR TITLE
Fix workflow failures in branch-dashboard.yml

### DIFF
--- a/.github/workflows/branch-dashboard.yml
+++ b/.github/workflows/branch-dashboard.yml
@@ -43,6 +43,10 @@ jobs:
                 owner, repo, basehead: `main...${b.name}`
               });
 
+              const commitData = await github.rest.repos.getCommit({
+                owner, repo, ref: b.commit.sha
+              });
+
               rows.push({
                 branch: b.name,
                 linked_pr: prByHead.get(b.name) || null,
@@ -51,7 +55,7 @@ jobs:
                 behind_by: cmp.data.behind_by,
                 duplicate_sha: bySha.get(b.commit.sha).length > 1,
                 commit_sha: b.commit.sha,
-                last_commit_date: b.commit.commit.author.date
+                last_commit_date: commitData.data.commit.author.date
               });
             }
 


### PR DESCRIPTION
Fixes the `TypeError: Cannot read properties of undefined (reading 'author')` error in `.github/workflows/branch-dashboard.yml`.

Also investigated the `daily-empire.yml` failure and determined it was an external configuration issue regarding the `EMAIL_PASS` secret not using a Google App Password. I have informed the user of this needed configuration change.

---
*PR created automatically by Jules for task [15467072939256663452](https://jules.google.com/task/15467072939256663452) started by @mrdannyclark82*

## Summary by Sourcery

Bug Fixes:
- Prevent `TypeError` in `branch-dashboard.yml` by retrieving commit details via the GitHub REST API before accessing the commit author date.