### PR TITLE
fix(android): restore ChatViewModel build

### DIFF
--- a/android/app/src/main/java/com/millarayne/ui/ChatViewModel.kt
+++ b/android/app/src/main/java/com/millarayne/ui/ChatViewModel.kt
@@ -34,7 +34,6 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
         messageDao = database.messageDao()
         offlineGenerator = OfflineResponseGenerator(application)
         loadMessages()
-        syncPendingMessages() // Try to sync any offline messages on startup
     }
 
     override fun onCleared() {
@@ -54,28 +53,6 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
-    // Basic sync function to retry sending unsynced messages
-    fun syncPendingMessages() {
-        viewModelScope.launch {
-            val unsynced = messageDao.getUnsyncedMessages()
-            if (unsynced.isEmpty()) return@launch
-
-            unsynced.forEach { msg ->
-                try {
-                    val response = MillaApiClient.apiService.sendMessage(ChatRequest(message = msg.content))
-                    if (response.isSuccessful) {
-                        messageDao.markAsSynced(msg.id)
-                        // Note: We might get a duplicate response if we don't handle it carefully,
-                        // but for now, we just ensure the user message reaches the server.
-                        // Ideally, the server would handle deduping or we'd handle the delayed response.
-                    }
-                } catch (e: Exception) {
-                    // Still offline, skip
-                }
-            }
-        }
-    }
-
     fun sendMessage(content: String) {
         viewModelScope.launch {
             _isLoading.value = true
@@ -85,13 +62,11 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
             val userMessage = Message(
                 content = content.trim(),
                 role = "user",
-                timestamp = System.currentTimeMillis(),
-                isSynced = false
+                timestamp = System.currentTimeMillis()
             )
 
-            var messageId: Long = 0
             try {
-                messageId = messageDao.insertMessage(userMessage)
+                messageDao.insertMessage(userMessage)
             } catch (e: Exception) {
                 _error.value = "Failed to save message: ${e.message}"
                 _isLoading.value = false
@@ -109,8 +84,6 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
                     assistantResponseText = response.body()?.response
                     _isOfflineMode.value = false // Successful connection
 
-                    // Mark as synced since it reached the server
-                    messageDao.markAsSynced(messageId)
                 } else {
                     throw Exception("Server returned ${response.code()}")
                 }
@@ -120,7 +93,7 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
                 _isOfflineMode.value = true
 
                 try {
-                    assistantResponseText = offlineGenerator.generateResponse(content)
+                    assistantResponseText = offlineGenerator.generateResponse(content).first
                 } catch (offlineErr: Exception) {
                     _error.value = "Both online and offline assistants failed."
                 }
@@ -131,8 +104,7 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
                 val assistantMessage = Message(
                     content = assistantResponseText,
                     role = "assistant",
-                    timestamp = System.currentTimeMillis(),
-                    isSynced = true // Local responses considered synced/local-only
+                    timestamp = System.currentTimeMillis()
                 )
                 try {
                     messageDao.insertMessage(assistantMessage)


### PR DESCRIPTION
Fixes the stale UI ChatViewModel references to removed message synchronization APIs and correctly unwraps the offline response result.\n\nThis is the Android compilation blocker exposed after workflow #876 enabled the build to reach Kotlin compilation.

## Summary by Sourcery

Restore the Android ChatViewModel build by removing obsolete message sync handling and aligning with the updated offline response API.

Bug Fixes:
- Fix ChatViewModel to use the updated offline response generator return type instead of the old API.
- Remove references to deprecated message synchronization fields and methods that were breaking compilation.