### PR TITLE
Fix Branch Dashboard Snapshot date parsing

### DIFF
--- a/.github/workflows/branch-dashboard.yml
+++ b/.github/workflows/branch-dashboard.yml
@@ -42,6 +42,9 @@ jobs:
               const cmp = await github.rest.repos.compareCommitsWithBasehead({
                 owner, repo, basehead: `main...${b.name}`
               });
+              const fullCommit = await github.rest.repos.getCommit({
+                owner, repo, ref: b.commit.sha
+              });
 
               rows.push({
                 branch: b.name,
@@ -51,7 +54,7 @@ jobs:
                 behind_by: cmp.data.behind_by,
                 duplicate_sha: bySha.get(b.commit.sha).length > 1,
                 commit_sha: b.commit.sha,
-                last_commit_date: b.commit.commit.author.date
+                last_commit_date: fullCommit.data.commit.author.date
               });
             }
 


### PR DESCRIPTION
Fixes a failure in the Branch Dashboard Snapshot workflow where `author` was undefined because `github.rest.repos.listBranches` only returns partial commit details (`sha` and `url`). The workflow now correctly fetches the full commit using `github.rest.repos.getCommit` before attempting to access `author.date`.

---
*PR created automatically by Jules for task [9053527016481161550](https://jules.google.com/task/9053527016481161550) started by @mrdannyclark82*

## Summary by Sourcery

Bug Fixes:
- Resolve undefined author metadata in the Branch Dashboard Snapshot by retrieving full commit data instead of relying on partial branch commit info.