### PR TITLE
fix: fetch full commit details in branch dashboard snapshot

### DIFF
--- a/.github/workflows/branch-dashboard.yml
+++ b/.github/workflows/branch-dashboard.yml
@@ -43,6 +43,10 @@ jobs:
                 owner, repo, basehead: `main...${b.name}`
               });
 
+              const commitData = await github.rest.repos.getCommit({
+                owner, repo, ref: b.commit.sha
+              });
+
               rows.push({
                 branch: b.name,
                 linked_pr: prByHead.get(b.name) || null,
@@ -51,7 +55,7 @@ jobs:
                 behind_by: cmp.data.behind_by,
                 duplicate_sha: bySha.get(b.commit.sha).length > 1,
                 commit_sha: b.commit.sha,
-                last_commit_date: b.commit.commit.author.date
+                last_commit_date: commitData.data.commit.author.date
               });
             }
 


### PR DESCRIPTION
The Branch Dashboard Snapshot workflow was failing because it attempted to access `author.date` on the branch commit object returned by `listBranches`, which only contains a `sha` and `url`. This PR resolves the issue by explicitly fetching the commit data using `getCommit`.

(Note: The failure in the Daily Empire Report workflow was identified as an external credential issue related to the `EMAIL_PASS` secret and Google's SMTP requirements. No infrastructure changes were required for it; the user has been notified).

---
*PR created automatically by Jules for task [12257503777910279167](https://jules.google.com/task/12257503777910279167) started by @mrdannyclark82*

## Summary by Sourcery

Bug Fixes:
- Fix Branch Dashboard Snapshot workflow failure by retrieving commit metadata with getCommit instead of relying on incomplete branch commit data.