### PR TITLE
Fix Branch Dashboard workflow failing due to undefined author date

### DIFF
--- a/.github/workflows/branch-dashboard.yml
+++ b/.github/workflows/branch-dashboard.yml
@@ -43,6 +43,10 @@ jobs:
                 owner, repo, basehead: `main...${b.name}`
               });
 
+              const commitDetail = await github.rest.repos.getCommit({
+                owner, repo, ref: b.commit.sha
+              });
+
               rows.push({
                 branch: b.name,
                 linked_pr: prByHead.get(b.name) || null,
@@ -51,7 +55,7 @@ jobs:
                 behind_by: cmp.data.behind_by,
                 duplicate_sha: bySha.get(b.commit.sha).length > 1,
                 commit_sha: b.commit.sha,
-                last_commit_date: b.commit.commit.author.date
+                last_commit_date: commitDetail.data.commit.author.date
               });
             }
 


### PR DESCRIPTION
Resolved the workflow failure in `Branch Dashboard Snapshot` caused by a missing `author.date` property on partial commit objects returned by `listBranches`. This fix uses the `getCommit` REST API to retrieve the full commit payload.

Additionally, diagnosed the `Daily Empire Report` failure (SMTP authentication rejection) and advised the user to verify the `EMAIL_PASS` secret contains a valid Google App Password.

---
*PR created automatically by Jules for task [6981312756564316719](https://jules.google.com/task/6981312756564316719) started by @mrdannyclark82*

## Summary by Sourcery

Bug Fixes:
- Prevent Branch Dashboard Snapshot job from failing when branch commit objects omit the author date field.