### PR TITLE
fix(workflows): handle no common ancestor errors when comparing branches

### DIFF
--- a/.github/workflows/branch-dashboard.yml
+++ b/.github/workflows/branch-dashboard.yml
@@ -39,19 +39,34 @@ jobs:
             }
 
             for (const b of branches) {
-              const cmp = await github.rest.repos.compareCommitsWithBasehead({
-                owner, repo, basehead: `main...${b.name}`
+              let merged = false;
+              let ahead_by = 0;
+              let behind_by = 0;
+
+              try {
+                const cmp = await github.rest.repos.compareCommitsWithBasehead({
+                  owner, repo, basehead: `main...${b.name}`
+                });
+                merged = cmp.data.status === 'behind' || cmp.data.status === 'identical';
+                ahead_by = cmp.data.ahead_by;
+                behind_by = cmp.data.behind_by;
+              } catch (err) {
+                console.log(`Could not compare ${b.name} with main: ${err.message}`);
+              }
+
+              const fullCommit = await github.rest.repos.getCommit({
+                owner, repo, ref: b.commit.sha
               });
 
               rows.push({
                 branch: b.name,
                 linked_pr: prByHead.get(b.name) || null,
-                merged: cmp.data.status === 'behind' || cmp.data.status === 'identical',
-                ahead_by: cmp.data.ahead_by,
-                behind_by: cmp.data.behind_by,
+                merged: merged,
+                ahead_by: ahead_by,
+                behind_by: behind_by,
                 duplicate_sha: bySha.get(b.commit.sha).length > 1,
                 commit_sha: b.commit.sha,
-                last_commit_date: b.commit.commit.author.date
+                last_commit_date: fullCommit.data.commit.author.date
               });
             }
 

--- a/.github/workflows/branch-janitor-weekly.yml
+++ b/.github/workflows/branch-janitor-weekly.yml
@@ -34,12 +34,17 @@ jobs:
 
             // 1) Delete no-PR branches already merged (main ahead or identical)
             for (const b of noPrBranches) {
-              const cmp = await github.rest.repos.compareCommitsWithBasehead({
-                owner, repo, basehead: `main...${b.name}`
-              });
-              const status = cmp.data.status;
-              if (status === 'behind' || status === 'identical') {
-                await github.rest.git.deleteRef({ owner, repo, ref: `heads/${b.name}` });
+              try {
+                const cmp = await github.rest.repos.compareCommitsWithBasehead({
+                  owner, repo, basehead: `main...${b.name}`
+                });
+                const status = cmp.data.status;
+                if (status === 'behind' || status === 'identical') {
+                  await github.rest.git.deleteRef({ owner, repo, ref: `heads/${b.name}` });
+                }
+              } catch (err) {
+                console.log(`Skipping branch ${b.name}: ${err.message}`);
+                continue;
               }
             }
 


### PR DESCRIPTION
Resolves GitHub Actions workflow failures caused by uncaught errors in `github-script` steps.

- Modifies `branch-dashboard.yml` to correctly fetch the full commit data to get author dates, and wraps branch basehead comparisons in a `try/catch` to handle orphan branch API errors without failing the workflow.
- Modifies `branch-janitor-weekly.yml` to wrap branch basehead comparisons in a `try/catch`, ensuring the cleanup loop gracefully skips branches missing common ancestors instead of terminating abruptly.
- User advised on `EMAIL_PASS` App Password requirement for the SMTP error in `daily-analysis.cjs`.

---
*PR created automatically by Jules for task [9791965989860087824](https://jules.google.com/task/9791965989860087824) started by @mrdannyclark82*

## Summary by Sourcery

Handle GitHub Actions branch comparison failures caused by branches without a common ancestor, and improve branch metadata collection in dashboard workflows.

Bug Fixes:
- Prevent branch-dashboard workflow from failing when compareCommitsWithBasehead throws on orphan or problematic branches.
- Ensure branch-janitor weekly cleanup skips branches that cannot be compared to main instead of aborting the job.
- Use full commit data to reliably obtain author dates for branches in the dashboard output.

CI:
- Update branch-dashboard GitHub Actions workflow to wrap branch comparison calls in error handling and fetch full commit details for each branch.
- Update branch-janitor-weekly GitHub Actions workflow to add error handling around branch comparison before deleting merged no-PR branches.